### PR TITLE
Separate out various tasks in the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,18 @@
-all:
-	tclsh model_gen.tcl model/uhdm.yaml
-	${CC} -g src/main.cpp src/vpi_user.cpp -I. -l stdc++ -o test
-	chmod 777 ./test
-	./test
+GENERATED_HEADERS=headers/module.h headers/design.h
+GENERATED_SOURCE=src/vpi_user.cpp
+
+all: generate-api run-test
+
+generate-api: $(GENERATED_SOURCE)
+
+$(GENERATED_SOURCE): model_gen.tcl model/uhdm.yaml
+	tclsh ./model_gen.tcl model/uhdm.yaml
+
+unittest: src/vpi_user.cpp
+	$(CXX) -g src/main.cpp src/vpi_user.cpp -I. -o $@
+
+run-test: unittest
+	./unittest
+
+clean:
+	rm -f $(GENERATED_SOURCE) $(GENERATED_HEADERS) unittest


### PR DESCRIPTION
  * generating API
  * build and run unittest
  * add `make clean`

Signed-off-by: Henner Zeller <h.zeller@acm.org>