### PR TITLE
Use C++ styleguide conventions.

### DIFF
--- a/headers/design.h
+++ b/headers/design.h
@@ -33,19 +33,19 @@ namespace UHDM {
     design(){}
     virtual ~design(){}
     
-    const VectorOfmodulePtr get_allModules() { return m_allModules; }
+    const VectorOfmodulePtr get_allModules() const { return allModules_; }
 
-    void set_allModules(VectorOfmodulePtr data) { m_allModules = data; }
+    void set_allModules(VectorOfmodulePtr data) { allModules_ = data; }
 
-    const VectorOfmodulePtr get_topModules() { return m_topModules; }
+    const VectorOfmodulePtr get_topModules() const { return topModules_; }
 
-    void set_topModules(VectorOfmodulePtr data) { m_topModules = data; }
+    void set_topModules(VectorOfmodulePtr data) { topModules_ = data; }
 
   private:
     
-    VectorOfmodulePtr m_allModules;
+    VectorOfmodulePtr allModules_;
 
-    VectorOfmodulePtr m_topModules;
+    VectorOfmodulePtr topModules_;
 
   };
 

--- a/headers/module.h
+++ b/headers/module.h
@@ -33,19 +33,19 @@ namespace UHDM {
     module(){}
     virtual ~module(){}
     
-    bool get_vpiTopModule() { return m_vpiTopModule; }
+    bool get_vpiTopModule() const { return vpiTopModule_; }
 
-    void set_vpiTopModule(bool data) { m_vpiTopModule = data; }
+    void set_vpiTopModule(bool data) { vpiTopModule_ = data; }
 
-    int get_vpiDefDecayTime() { return m_vpiDefDecayTime; }
+    int get_vpiDefDecayTime() const { return vpiDefDecayTime_; }
 
-    void set_vpiDefDecayTime(int data) { m_vpiDefDecayTime = data; }
+    void set_vpiDefDecayTime(int data) { vpiDefDecayTime_ = data; }
 
   private:
     
-    bool m_vpiTopModule;
+    bool vpiTopModule_;
 
-    int m_vpiDefDecayTime;
+    int vpiDefDecayTime_;
 
   };
 

--- a/model_gen.tcl
+++ b/model_gen.tcl
@@ -134,20 +134,20 @@ proc parse_model { file } {
 
 proc printMethods { type vpi card } {
     if {$card == "1"} {
-	append methods "\n    $type get_${vpi}() { return m_$vpi; }\n"
-	append methods "\n    void set_${vpi}($type data) { m_$vpi = data; }\n"
+	append methods "\n    $type get_${vpi}() const { return ${vpi}_; }\n"
+	append methods "\n    void set_${vpi}($type data) { ${vpi}_ = data; }\n"
     } elseif {$card == "any"} {
-	append methods "\n    const VectorOf${type}Ptr get_${vpi}() { return m_$vpi; }\n"
-	append methods "\n    void set_${vpi}(VectorOf${type}Ptr data) { m_$vpi = data; }\n"	
+	append methods "\n    const VectorOf${type}Ptr get_${vpi}() const { return ${vpi}_; }\n"
+	append methods "\n    void set_${vpi}(VectorOf${type}Ptr data) { ${vpi}_ = data; }\n"
     }
     return $methods
 }
 
 proc printMembers { type vpi card } {
     if {$card == "1"} {
-	append members "\n    $type m_$vpi;\n"
+	append members "\n    $type ${vpi}_;\n"
     } elseif {$card == "any"} {
-	append members "\n    VectorOf${type}Ptr m_$vpi;\n"	
+	append members "\n    VectorOf${type}Ptr ${vpi}_;\n"
     }
 }
 
@@ -160,7 +160,7 @@ proc printTypeDefs { containerId type card } {
 	    puts $containerId "typedef std::vector<${type}*> VectorOf${type};"
 	    puts $containerId "typedef std::vector<${type}*>* VectorOf${type}Ptr;"
 	    puts $containerId "typedef std::vector<${type}*>& VectorOf${type}Ref;"
-	    puts $containerId "typedef std::vector<${type}*>::iterator VectorOf${type}Itr;"	   
+	    puts $containerId "typedef std::vector<${type}*>::iterator VectorOf${type}Itr;"
 	}
     }
 }


### PR DESCRIPTION
From https://google.github.io/styleguide/cppguide.html

  * Names in member variables shall be foo_ (not m_foo)
  * getters that don't modify anything should be const.

Also, getters should not start with get_ (such as get_foo()),
but named foo(). However currently the name conflicts with a #define,
so that needs to be changed separately if possible.

Signed-off-by: Henner Zeller <h.zeller@acm.org>