### PR TITLE
Styleguide improvements.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: generate-api run-test
 
 generate-api: $(GENERATED_SOURCE)
 
-$(GENERATED_SOURCE): model_gen.tcl model/uhdm.yaml
+$(GENERATED_SOURCE): model_gen.tcl model/uhdm.yaml templates/vpi_user.cpp
 	tclsh ./model_gen.tcl model/uhdm.yaml
 
 unittest: src/vpi_user.cpp

--- a/headers/design.h
+++ b/headers/design.h
@@ -28,10 +28,10 @@
 
 namespace UHDM {
 
-  class design : public base_class {
+  class design : public BaseClass {
   public:
     design(){}
-    virtual ~design(){}
+    ~design() final {}
     
     const VectorOfmodulePtr get_allModules() { return m_allModules; }
 

--- a/headers/module.h
+++ b/headers/module.h
@@ -28,10 +28,10 @@
 
 namespace UHDM {
 
-  class module : public base_class {
+  class module : public BaseClass {
   public:
     module(){}
-    virtual ~module(){}
+    ~module() final {}
     
     bool get_vpiTopModule() { return m_vpiTopModule; }
 

--- a/include/vpi_uhdm.h
+++ b/include/vpi_uhdm.h
@@ -1,18 +1,18 @@
+// -*- c++ -*-
 namespace UHDM {
-  
-  class base_class {
-  public:
-    base_class(){}
-    virtual ~base_class(){}
-  };
-
+class BaseClass {
+public:
+  BaseClass(){}
+  virtual ~BaseClass(){}
+};
 };
 
 
-typedef struct uhdm_handle {
+struct uhdm_handle {
   uhdm_handle(unsigned int type, void* object) :
-  m_type(type), m_object(object), m_index(0) {}
-  unsigned int m_type;
-  void* m_object;
-  unsigned int m_index;
-} uhdm_handle;
+    type(type), object(object), index(0) {}
+
+  unsigned int type;
+  void* object;
+  unsigned int index;
+};

--- a/model_gen.tcl
+++ b/model_gen.tcl
@@ -234,18 +234,18 @@ namespace UHDM {"
 		    
 		    if {$card == "any"} {
 			append vpi_iterate_body "\n\    
-if (handle->m_type == ${classname}ID) {\                
+if (handle->type == ${classname}ID) {\n\
   if (type == $name) {\n\
     return (vpiHandle) new uhdm_handle($name, (($classname*)(object))->get_${name}());\n\
 		      }\n\
 				       }\n"
 
                      append vpi_scan_body "\n
-  if (handle->m_type == $name) {\n\
+  if (handle->type == $name) {\n\
     VectorOf${type}Ptr the_vec = (VectorOf${type}Ptr)vect;\n\
-      if (handle->m_index < the_vec->size()) {\n\
-          uhdm_handle* h = new uhdm_handle(${type}ID, the_vec->at(handle->m_index));\n\
-	  handle->m_index++;\n\
+      if (handle->index < the_vec->size()) {\n\
+          uhdm_handle* h = new uhdm_handle(${type}ID, the_vec->at(handle->index));\n\
+	  handle->index++;\n\
           return (vpiHandle) h;\n\
       }\n\
   }"

--- a/src/vpi_user.cpp
+++ b/src/vpi_user.cpp
@@ -37,18 +37,18 @@ using namespace UHDM;
 
 vpiHandle vpi_iterate (PLI_INT32 type, vpiHandle refHandle) {
   uhdm_handle* handle = (uhdm_handle*) refHandle;
-  base_class*  object = (base_class*) handle->m_object;
+  BaseClass*  object = (BaseClass*) handle->object;
   
     
-if (handle->m_type == designID) {                
-  if (type == allModules) {
+if (handle->type == designID) {
+ if (type == allModules) {
  return (vpiHandle) new uhdm_handle(allModules, ((design*)(object))->get_allModules());
  }
  }
 
     
-if (handle->m_type == designID) {                
-  if (type == topModules) {
+if (handle->type == designID) {
+ if (type == topModules) {
  return (vpiHandle) new uhdm_handle(topModules, ((design*)(object))->get_topModules());
  }
  }
@@ -57,23 +57,23 @@ if (handle->m_type == designID) {
 
 vpiHandle vpi_scan (vpiHandle iterator) {
   uhdm_handle* handle = (uhdm_handle*) iterator;
-  void* vect = handle->m_object;
+  void* vect = handle->object;
   
 
-  if (handle->m_type == allModules) {
+  if (handle->type == allModules) {
  VectorOfmodulePtr the_vec = (VectorOfmodulePtr)vect;
- if (handle->m_index < the_vec->size()) {
- uhdm_handle* h = new uhdm_handle(moduleID, the_vec->at(handle->m_index));
- handle->m_index++;
+ if (handle->index < the_vec->size()) {
+ uhdm_handle* h = new uhdm_handle(moduleID, the_vec->at(handle->index));
+ handle->index++;
  return (vpiHandle) h;
  }
  }
 
-  if (handle->m_type == topModules) {
+  if (handle->type == topModules) {
  VectorOfmodulePtr the_vec = (VectorOfmodulePtr)vect;
- if (handle->m_index < the_vec->size()) {
- uhdm_handle* h = new uhdm_handle(moduleID, the_vec->at(handle->m_index));
- handle->m_index++;
+ if (handle->index < the_vec->size()) {
+ uhdm_handle* h = new uhdm_handle(moduleID, the_vec->at(handle->index));
+ handle->index++;
  return (vpiHandle) h;
  }
  }

--- a/templates/class_header.h
+++ b/templates/class_header.h
@@ -28,10 +28,10 @@
 
 namespace UHDM {
 
-  class <CLASSNAME> : public base_class {
+  class <CLASSNAME> : public BaseClass {
   public:
     <CLASSNAME>(){}
-    virtual ~<CLASSNAME>(){}
+    ~<CLASSNAME>() final {}
     <METHODS>
   private:
     <MEMBERS>

--- a/templates/vpi_user.cpp
+++ b/templates/vpi_user.cpp
@@ -35,13 +35,13 @@ using namespace UHDM;
 
 vpiHandle vpi_iterate (PLI_INT32 type, vpiHandle refHandle) {
   uhdm_handle* handle = (uhdm_handle*) refHandle;
-  base_class*  object = (base_class*) handle->m_object;
+  BaseClass*  object = (BaseClass*) handle->object;
   <VPI_ITERATE_BODY>
 }
 
 vpiHandle vpi_scan (vpiHandle iterator) {
   uhdm_handle* handle = (uhdm_handle*) iterator;
-  void* vect = handle->m_object;
+  void* vect = handle->object;
   <VPI_SCAN_BODY>
   return 0;
 }


### PR DESCRIPTION
More improvements following style-guide
https://google.github.io/styleguide/cppguide.html

  * Member names of struct: don't use special notation
    (such as m_foo or foo_). Since these are implicitly public,
    they are to be seen as directly accessed variables.
  * Class name: make Upper-case (currently only BaseClass, for
    the generated ones, the yaml file needs changing).
  * In the derived classes: use 'final' (for now until we run
    into to deeper hierarchies).

Signed-off-by: Henner Zeller <h.zeller@acm.org>