### PR TITLE
Don't typedef pointer and reference types.

### DIFF
--- a/headers/containers.h
+++ b/headers/containers.h
@@ -3,8 +3,6 @@
 namespace UHDM {
 class module;
 typedef std::vector<module*> VectorOfmodule;
-typedef std::vector<module*>* VectorOfmodulePtr;
-typedef std::vector<module*>& VectorOfmoduleRef;
 typedef std::vector<module*>::iterator VectorOfmoduleItr;
 };
 #endif

--- a/headers/design.h
+++ b/headers/design.h
@@ -33,19 +33,19 @@ namespace UHDM {
     design(){}
     ~design() final {}
     
-    VectorOfmodulePtr get_allModules() const { return allModules_; }
+    VectorOfmodule* get_allModules() const { return allModules_; }
 
-    void set_allModules(VectorOfmodulePtr data) { allModules_ = data; }
+    void set_allModules(VectorOfmodule* data) { allModules_ = data; }
 
-    VectorOfmodulePtr get_topModules() const { return topModules_; }
+    VectorOfmodule* get_topModules() const { return topModules_; }
 
-    void set_topModules(VectorOfmodulePtr data) { topModules_ = data; }
+    void set_topModules(VectorOfmodule* data) { topModules_ = data; }
 
   private:
     
-    VectorOfmodulePtr allModules_;
+    VectorOfmodule* allModules_;
 
-    VectorOfmodulePtr topModules_;
+    VectorOfmodule* topModules_;
 
   };
 

--- a/model_gen.tcl
+++ b/model_gen.tcl
@@ -162,8 +162,8 @@ proc printMethods { type vpi card } {
 	append methods "\n    $type get_${vpi}() const { return ${vpi}_; }\n"
 	append methods "\n    void set_${vpi}($type data) { ${vpi}_ = data; }\n"
     } elseif {$card == "any"} {
-	append methods "\n    VectorOf${type}Ptr get_${vpi}() const { return ${vpi}_; }\n"
-	append methods "\n    void set_${vpi}(VectorOf${type}Ptr data) { ${vpi}_ = data; }\n"
+	append methods "\n    VectorOf${type}* get_${vpi}() const { return ${vpi}_; }\n"
+	append methods "\n    void set_${vpi}(VectorOf${type}* data) { ${vpi}_ = data; }\n"
     }
     return $methods
 }
@@ -175,7 +175,7 @@ proc printMembers { type vpi card } {
     if {$card == "1"} {
 	append members "\n    $type ${vpi}_;\n"
     } elseif {$card == "any"} {
-	append members "\n    VectorOf${type}Ptr ${vpi}_;\n"
+	append members "\n    VectorOf${type}* ${vpi}_;\n"
     }
 }
 
@@ -186,8 +186,6 @@ proc printTypeDefs { containerId type card } {
 	    set CONTAINER($type) 1
 	    puts $containerId "class $type;"
 	    puts $containerId "typedef std::vector<${type}*> VectorOf${type};"
-	    puts $containerId "typedef std::vector<${type}*>* VectorOf${type}Ptr;"
-	    puts $containerId "typedef std::vector<${type}*>& VectorOf${type}Ref;"
 	    puts $containerId "typedef std::vector<${type}*>::iterator VectorOf${type}Itr;"
 	}
     }
@@ -239,7 +237,7 @@ proc printScanBody { name type card } {
     if {$card == "any"} {
 	append vpi_scan_body "\n
   if (handle->type == $name) {\n\
-    VectorOf${type}Ptr the_vec = (VectorOf${type}Ptr)vect;\n\
+    VectorOf${type}* the_vec = (VectorOf${type}*)vect;\n\
       if (handle->index < the_vec->size()) {\n\
           uhdm_handle* h = new uhdm_handle(${type}ID, the_vec->at(handle->index));\n\
 	  handle->index++;\n\

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@ int main (int argc, char** argv) {
   m1->set_vpiName("M1");
   module* m2 = new module();
   m2->set_vpiName("M2");
-  VectorOfmodulePtr v1 = new VectorOfmodule;
+  VectorOfmodule* v1 = new VectorOfmodule();
   v1->push_back(m1);
   v1->push_back(m2);
   d->set_allModules(v1);

--- a/src/vpi_user.cpp
+++ b/src/vpi_user.cpp
@@ -97,7 +97,7 @@ vpiHandle vpi_scan (vpiHandle iterator) {
   
 
   if (handle->type == allModules) {
- VectorOfmodulePtr the_vec = (VectorOfmodulePtr)vect;
+ VectorOfmodule* the_vec = (VectorOfmodule*)vect;
  if (handle->index < the_vec->size()) {
  uhdm_handle* h = new uhdm_handle(moduleID, the_vec->at(handle->index));
  handle->index++;
@@ -106,7 +106,7 @@ vpiHandle vpi_scan (vpiHandle iterator) {
  }
 
   if (handle->type == topModules) {
- VectorOfmodulePtr the_vec = (VectorOfmodulePtr)vect;
+ VectorOfmodule* the_vec = (VectorOfmodule*)vect;
  if (handle->index < the_vec->size()) {
  uhdm_handle* h = new uhdm_handle(moduleID, the_vec->at(handle->index));
  handle->index++;


### PR DESCRIPTION
Unless really needed, using typedef on pointers and reference types
is reducing readability because very crucial information useful for
the reader of the code is hidden behind an opaque type. Using '*' and
'&' directly gives the reader the necessary clues.

Signed-off-by: Henner Zeller <h.zeller@acm.org>