### PR TITLE
Use const where possible.

### DIFF
--- a/headers/design.h
+++ b/headers/design.h
@@ -33,11 +33,11 @@ namespace UHDM {
     design(){}
     ~design() final {}
     
-    VectorOfmodule* get_allModules() const { return allModules_; }
+    const VectorOfmodule* get_allModules() const { return allModules_; }
 
     void set_allModules(VectorOfmodule* data) { allModules_ = data; }
 
-    VectorOfmodule* get_topModules() const { return topModules_; }
+    const VectorOfmodule* get_topModules() const { return topModules_; }
 
     void set_topModules(VectorOfmodule* data) { topModules_ = data; }
 

--- a/include/vpi_uhdm.h
+++ b/include/vpi_uhdm.h
@@ -13,11 +13,11 @@ public:
 
 
 struct uhdm_handle {
-  uhdm_handle(unsigned int type, void* object) :
+  uhdm_handle(unsigned int type, const void* object) :
     type(type), object(object), index(0) {}
 
-  unsigned int type;
-  void* object;
+  const unsigned int type;
+  const void* object;
   unsigned int index;
 };
 

--- a/model_gen.tcl
+++ b/model_gen.tcl
@@ -162,7 +162,7 @@ proc printMethods { type vpi card } {
 	append methods "\n    $type get_${vpi}() const { return ${vpi}_; }\n"
 	append methods "\n    void set_${vpi}($type data) { ${vpi}_ = data; }\n"
     } elseif {$card == "any"} {
-	append methods "\n    VectorOf${type}* get_${vpi}() const { return ${vpi}_; }\n"
+	append methods "\n    const VectorOf${type}* get_${vpi}() const { return ${vpi}_; }\n"
 	append methods "\n    void set_${vpi}(VectorOf${type}* data) { ${vpi}_ = data; }\n"
     }
     return $methods

--- a/src/vpi_user.cpp
+++ b/src/vpi_user.cpp
@@ -71,8 +71,8 @@ vpiHandle vpi_handle_multi (PLI_INT32 type,
 }
 
 vpiHandle vpi_iterate (PLI_INT32 type, vpiHandle refHandle) {
-  uhdm_handle* handle = (uhdm_handle*) refHandle;
-  BaseClass*  object = (BaseClass*) handle->object;
+  const uhdm_handle* const handle = (uhdm_handle*) refHandle;
+  const BaseClass*  object = (BaseClass*) handle->object;
   
     
  if (handle->type == designID) {
@@ -92,8 +92,8 @@ vpiHandle vpi_iterate (PLI_INT32 type, vpiHandle refHandle) {
 }
 
 vpiHandle vpi_scan (vpiHandle iterator) {
-  uhdm_handle* handle = (uhdm_handle*) iterator;
-  void* vect = handle->object;
+  uhdm_handle* const handle = (uhdm_handle*) iterator;
+  const void* const vect = handle->object;
   
 
   if (handle->type == allModules) {

--- a/templates/vpi_user.cpp
+++ b/templates/vpi_user.cpp
@@ -63,15 +63,15 @@ vpiHandle vpi_handle_multi (PLI_INT32 type,
 }
 
 vpiHandle vpi_iterate (PLI_INT32 type, vpiHandle refHandle) {
-  uhdm_handle* handle = (uhdm_handle*) refHandle;
-  BaseClass*  object = (BaseClass*) handle->object;
+  const uhdm_handle* const handle = (uhdm_handle*) refHandle;
+  const BaseClass*  object = (BaseClass*) handle->object;
   <VPI_ITERATE_BODY>
   return 0;   
 }
 
 vpiHandle vpi_scan (vpiHandle iterator) {
-  uhdm_handle* handle = (uhdm_handle*) iterator;
-  void* vect = handle->object;
+  uhdm_handle* const handle = (uhdm_handle*) iterator;
+  const void* const vect = handle->object;
   <VPI_SCAN_BODY>
   return 0;
 }


### PR DESCRIPTION
Getter methods that are marked const should also only return
const pointers so that the intent ('nothing is changed') is
preserved (if we return a non-const pointer, we can modify internals
of the object).

Add slight changes where they are used.

Signed-off-by: Henner Zeller <h.zeller@acm.org>