### PR TITLE
o Make test_helper.h self-contained (include all the headers it

### DIFF
--- a/tests/test1.cpp
+++ b/tests/test1.cpp
@@ -1,10 +1,12 @@
-#include "headers/uhdm.h"
-#include <iostream>
- 
-using namespace UHDM;
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
 
-#include "test_helper.h"
+#include "headers/uhdm.h"
 #include "headers/vpi_visitor.h"
+#include "test_helper.h"
+
+#include <iostream>
+
+using namespace UHDM;
 
 std::vector<vpiHandle> build_designs (Serializer& s) {
   std::vector<vpiHandle> designs;
@@ -82,9 +84,9 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
   f3->VpiName("MyFunc3");
   f3->VpiSize(300);
   f3->VpiParent(m1);
-  inst_items->push_back(f3); 
+  inst_items->push_back(f3);
   m1->Instance_items(inst_items);
-  
+
   designs.push_back(s.MakeUhdmHandle(uhdmdesign, d));
   return designs;
 }
@@ -96,16 +98,16 @@ int main (int argc, char** argv) {
   std::string orig = print_designs(designs);
   orig += "VISITOR:\n";
   orig += visit_designs(designs);
-  std::cout << orig; 
+  std::cout << orig;
   std::cout << "\nSave design" << std::endl;
   serializer.Save("surelog.uhdm");
-  
+
   std::cout << "Restore design" << std::endl;
   const std::vector<vpiHandle>& restoredDesigns = serializer.Restore("surelog.uhdm");
   std::string restored = print_designs(restoredDesigns);
   restored += "VISITOR:\n";
   restored += visit_designs(restoredDesigns);
   std::cout << restored;
-  
+
   return (orig != restored);
-};
+}

--- a/tests/test2.cpp
+++ b/tests/test2.cpp
@@ -1,6 +1,9 @@
-#include "headers/uhdm.h"
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+
 #include <iostream>
- 
+
+#include "headers/uhdm.h"
+
 using namespace UHDM;
 
 #include "test_helper.h"
@@ -13,8 +16,8 @@ int main (int argc, char** argv) {
   Serializer serializer;
   std::cout << "Restore design from: " << fileName << std::endl;
   std::vector<vpiHandle> restoredDesigns = serializer.Restore(fileName);
-  
+
   std::string restored = print_designs(restoredDesigns);
   std::cout << restored;
   return 0;
-};
+}

--- a/tests/test3.cpp
+++ b/tests/test3.cpp
@@ -1,6 +1,9 @@
-#include "headers/uhdm.h"
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+
 #include <iostream>
- 
+
+#include "headers/uhdm.h"
+
 using namespace UHDM;
 
 #include "test_helper.h"
@@ -48,15 +51,15 @@ int main (int argc, char** argv) {
   Serializer serializer;
 
   std::string orig = print_designs(build_designs(serializer));
-  
-  std::cout << orig; 
+
+  std::cout << orig;
   std::cout << "\nSave design" << std::endl;
   serializer.Save("surelog3.uhdm");
-  
+
   std::cout << "Restore design" << std::endl;
   std::vector<vpiHandle> restoredDesigns = serializer.Restore("surelog3.uhdm");
-  
+
   std::string restored = print_designs(restoredDesigns);
   std::cout << restored;
   return (orig != restored);
-};
+}

--- a/tests/test4.cpp
+++ b/tests/test4.cpp
@@ -1,9 +1,11 @@
-#include "headers/uhdm.h"
-#include <iostream>
- 
-using namespace UHDM;
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
 
+#include <iostream>
+
+#include "headers/uhdm.h"
 #include "test_helper.h"
+
+using namespace UHDM;
 
 int main (int argc, char** argv) {
   std::string fileName = "surelog.uhdm";
@@ -12,16 +14,16 @@ int main (int argc, char** argv) {
   }
   Serializer serializer1;
   std::cout << "Restore design from: " << fileName << std::endl;
-  std::vector<vpiHandle> restoredDesigns1 = serializer1.Restore(fileName);  
+  std::vector<vpiHandle> restoredDesigns1 = serializer1.Restore(fileName);
   std::string restored1 = print_designs(restoredDesigns1);
   std::cout << restored1;
 
   Serializer serializer2;
   fileName = "surelog3.uhdm";
   std::cout << "Restore design from: " << fileName << std::endl;
-  std::vector<vpiHandle> restoredDesigns2 = serializer2.Restore(fileName);  
+  std::vector<vpiHandle> restoredDesigns2 = serializer2.Restore(fileName);
   std::string restored2 = print_designs(restoredDesigns2);
   std::cout << restored2;
- 
+
   return 0;
-};
+}

--- a/tests/test_helper.h
+++ b/tests/test_helper.h
@@ -1,58 +1,67 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+#ifndef UHDM_TEST_HELPER_H
+#define UHDM_TEST_HELPER_H
 
+#include <string>
+#include <vector>
+
+#include "headers/uhdm_types.h"
+#include "include/sv_vpi_user.h"
 
 std::string print_designs (const std::vector<vpiHandle>& designs) {
   std::string result;
   for (auto restoredDesign : designs) {
     result += "Design name: " + std::string(vpi_get_str(vpiName, restoredDesign)) + "\n";
-    
+
     // VPI test
-    vpiHandle modItr = vpi_iterate(uhdmallModules,restoredDesign); 
+    vpiHandle modItr = vpi_iterate(UHDM::uhdmallModules, restoredDesign);
     while (vpiHandle obj_h = vpi_scan(modItr) ) {
       if (vpi_get(vpiType, obj_h) != vpiModule) {
-	result += "ERROR: this is not a module\n";
+        result += "ERROR: this is not a module\n";
       }
       result +=  "+ module:" + std::string(vpi_get_str(vpiName, obj_h))
-	+ ", top:" 
-	+ std::to_string(vpi_get(vpiTopModule, obj_h))
-	+ ", parent:" + std::string(vpi_get_str(vpiName, vpi_handle(vpiParent, obj_h)))
+        + ", top:"
+        + std::to_string(vpi_get(vpiTopModule, obj_h))
+        + ", parent:" + std::string(vpi_get_str(vpiName, vpi_handle(vpiParent, obj_h)))
         + ", file:" +  std::string(vpi_get_str(vpiFile, obj_h))
-	+ ", line:" + std::to_string(vpi_get(vpiLineNo, obj_h));
-      vpiHandle submodItr = vpi_iterate(vpiModule, obj_h); 
+        + ", line:" + std::to_string(vpi_get(vpiLineNo, obj_h));
+      vpiHandle submodItr = vpi_iterate(vpiModule, obj_h);
       while (vpiHandle sub_h = vpi_scan(submodItr) ) {
-	result += "\n    \\_ mod:" + std::string(vpi_get_str(vpiName, sub_h)) 
-	  + ", top:" + std::to_string(vpi_get(vpiTopModule, sub_h))
-	  + ", parent:" + std::string(vpi_get_str(vpiName, vpi_handle(vpiParent, sub_h)))
-	  + ", file:" +  std::string(vpi_get_str(vpiFile, sub_h))
-	  + ", line:" + std::to_string(vpi_get(vpiLineNo, sub_h));
-	vpi_release_handle (sub_h);
+        result += "\n    \\_ mod:" + std::string(vpi_get_str(vpiName, sub_h))
+          + ", top:" + std::to_string(vpi_get(vpiTopModule, sub_h))
+          + ", parent:" + std::string(vpi_get_str(vpiName, vpi_handle(vpiParent, sub_h)))
+          + ", file:" +  std::string(vpi_get_str(vpiFile, sub_h))
+          + ", line:" + std::to_string(vpi_get(vpiLineNo, sub_h));
+        vpi_release_handle (sub_h);
       }
       vpiHandle importItr = vpi_iterate(vpiImport, obj_h);
       while (vpiHandle sub_h = vpi_scan(importItr) ) {
-	result += "\n    \\_ inst_item:" + std::string(vpi_get_str(vpiName, sub_h));
-	if (vpiFunction == vpi_get(vpiType, sub_h))
-	    result += std::string(", size:") + std::to_string(vpi_get(vpiSize, sub_h));
+        result += "\n    \\_ inst_item:" + std::string(vpi_get_str(vpiName, sub_h));
+        if (vpiFunction == vpi_get(vpiType, sub_h))
+          result += std::string(", size:") + std::to_string(vpi_get(vpiSize, sub_h));
       }
-      vpi_release_handle (submodItr);    
+      vpi_release_handle (submodItr);
       result += "\n";
       vpi_release_handle (obj_h);
     }
     vpi_release_handle(modItr);
 
-    vpiHandle pacItr = vpi_iterate(uhdmallPackages,restoredDesign); 
+    vpiHandle pacItr = vpi_iterate(UHDM::uhdmallPackages, restoredDesign);
     while (vpiHandle obj_h = vpi_scan(pacItr) ) {
       if (vpi_get(vpiType, obj_h) != vpiPackage) {
-	result += "ERROR: this is not a package\n";
+        result += "ERROR: this is not a package\n";
       }
       result +=  "+ package: " + std::string(vpi_get_str(vpiName, obj_h)) + ", ";
       result +=  "def: " + std::string(vpi_get_str(vpiDefName, obj_h));
       result += "\n";
-      vpiHandle funcItr = vpi_iterate(vpiTaskFunc, obj_h); 
+      vpiHandle funcItr = vpi_iterate(vpiTaskFunc, obj_h);
       while (vpiHandle func_h = vpi_scan(funcItr) ) {
-	result +=  "  func: " + std::string(vpi_get_str(vpiName, func_h)) + std::string(", size:") + std::to_string(vpi_get(vpiSize, func_h));
-	result += "\n";
+        result +=  "  func: " + std::string(vpi_get_str(vpiName, func_h)) + std::string(", size:") + std::to_string(vpi_get(vpiSize, func_h));
+        result += "\n";
       }
     }
   }
   return result;
 }
 
+#endif  // UHDM_TEST_HELPER_H

--- a/tests/test_listener.cpp
+++ b/tests/test_listener.cpp
@@ -1,39 +1,42 @@
-#include "headers/uhdm.h"
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+
 #include <iostream>
 #include <stack>
+
+#include "headers/uhdm.h"
 #include "headers/vpi_listener.h"
 
 using namespace UHDM;
 
-
 class MyVpiListener : public VpiListener {
-
 protected:
   void enterModule(const module* object, const BaseClass* parent,
-		   vpiHandle handle, vpiHandle parentHandle) override {
+                   vpiHandle handle, vpiHandle parentHandle) override {
     std::cout << "Module: " << object->VpiName()
-	      << ", parent: " << vpi_get_str(vpiName, parentHandle) << std::endl;
+              << ", parent: " << vpi_get_str(vpiName, parentHandle)
+              << std::endl;
     stack_.push(object);
   }
 
   void leaveModule(const module* object, const BaseClass* parent,
-		   vpiHandle handle, vpiHandle parentHandle) override {
+                   vpiHandle handle, vpiHandle parentHandle) override {
     stack_.pop();
   }
-  
+
   void enterProgram(const program* object, const BaseClass* parent,
-		   vpiHandle handle, vpiHandle parentHandle) override {
-  std::cout << "Program: " << object->VpiName()
-	    << ", parent: " << vpi_get_str(vpiName, parentHandle) << std::endl;
+                    vpiHandle handle, vpiHandle parentHandle) override {
+    std::cout << "Program: " << object->VpiName()
+              << ", parent: " << vpi_get_str(vpiName, parentHandle)
+              << std::endl;
     stack_.push(object);
   }
 
   void leaveProgram(const program* object, const BaseClass* parent,
-		   vpiHandle handle, vpiHandle parentHandle) override {
+                    vpiHandle handle, vpiHandle parentHandle) override {
     stack_.pop();
   }
-  
-private:  
+
+private:
   std::stack<const BaseClass*> stack_;
 };
 
@@ -42,10 +45,10 @@ int main (int argc, char** argv) {
   if (argc > 1) {
     fileName = argv[1];
   }
-  Serializer serializer1;
+  UHDM::Serializer serializer1;
   std::cout << "Restore design from: " << fileName << std::endl;
-  std::vector<vpiHandle> restoredDesigns = serializer1.Restore(fileName);  
+  std::vector<vpiHandle> restoredDesigns = serializer1.Restore(fileName);
   MyVpiListener* listener = new MyVpiListener();
   listen_designs(restoredDesigns,listener);
   return 0;
-};
+}


### PR DESCRIPTION
  needs and use namespace where needed)
o Make intendntation of all tests uniform.
o Order headers according to style-guide: system headers first,
  then project headers.
o sort headers alphanumerically (makes them easy to find and prevents
  merge conflicts)