### PR TITLE
Link to correct capnp: we want the one that is in the surelog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,5 @@ build:
 	cd build; cmake ../ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(PREFIX)
 
 test_install:
-	$(CXX) -std=c++14 -g tests/test1.cpp -I$(PREFIX)/include/uhdm -I$(PREFIX)/include/uhdm/include $(PREFIX)/lib/uhdm/libuhdm.a -lcapnp -lkj -ldl -lutil -lm -lrt -lpthread -o test_inst
+	$(CXX) -std=c++14 -g tests/test1.cpp -I$(PREFIX)/include/uhdm -I$(PREFIX)/include/uhdm/include $(PREFIX)/lib/uhdm/libuhdm.a -L$(PREFIX)/lib -lcapnp -lkj -ldl -lutil -lm -lrt -lpthread -o test_inst
 	./test_inst


### PR DESCRIPTION
installation, not the system one. Fixes #121

Signed-off-by: Henner Zeller <h.zeller@acm.org>