### PR TITLE
Disable capnproto tests to build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # -*- mode:cmake -*-
 cmake_minimum_required(VERSION 3.0)
 
+set(BUILD_TESTING OFF CACHE BOOL "Don't build capnproto tests")
 add_subdirectory(third_party/capnproto)
 
 # Detect build type, fallback to release and throw a warning if use didn't


### PR DESCRIPTION
We don't run them and they generate link issues in some
contexts.

Signed-off-by: Henner Zeller <h.zeller@acm.org>