### PR TITLE
Fixed group_def stmt, the back-arrow to process class is achieved by …

### DIFF
--- a/model/stmt.yaml
+++ b/model/stmt.yaml
@@ -17,9 +17,4 @@
 - group_def: stmt
   - class_ref: scope
   - class_ref: atomic_stmt
-  - class_ref: process
-    name: process
-    type: process
-    vpi: vpiProcess
-    card: 1
-  
+


### PR DESCRIPTION
…vpiParent relation.
@rkapuscik, a group only contains obj_ref or class_ref statements, with no properties.
The back-link to the process parent is achieved via vpiParent relation which is implicit in the model. Every object has that relation.