### PR TITLE
Use const reference instead of copying a string in a parameter.

### DIFF
--- a/templates/Serializer.h
+++ b/templates/Serializer.h
@@ -36,12 +36,12 @@ namespace UHDM {
     Serializer() : incrId_(0), objId_(0) {symbolMaker.Make("");}
     void Save(std::string file);
     void Purge();
-    const std::vector<vpiHandle> Restore(std::string file);
-   
-<FACTORIES_METHODS> 
+    const std::vector<vpiHandle> Restore(const std::string& file);
+
+<FACTORIES_METHODS>
     std::vector<any*>* MakeAnyVec() { return anyVectMaker.Make(); }
     vpiHandle MakeUhdmHandle(UHDM_OBJECT_TYPE type, const void* object) { return uhdm_handleMaker.Make(type, object); }
-    
+
     VectorOfanyFactory anyVectMaker;
     SymbolFactory symbolMaker;
     uhdm_handleFactory uhdm_handleMaker;

--- a/templates/Serializer_restore.cpp
+++ b/templates/Serializer_restore.cpp
@@ -49,7 +49,7 @@
 
 using namespace UHDM;
 
-const std::vector<vpiHandle> Serializer::Restore(std::string file) {
+const std::vector<vpiHandle> Serializer::Restore(const std::string& file) {
   Purge();
   std::vector<vpiHandle> designs;
   int fileid = open(file.c_str(), O_RDONLY);
@@ -64,16 +64,16 @@ const std::vector<vpiHandle> Serializer::Restore(std::string file) {
   for (auto symbol : symbols) {
     symbolMaker.Make(symbol);
   }
- 
-<CAPNP_INIT_FACTORIES>  
-  
-<CAPNP_RESTORE_FACTORIES>  
-  
+
+<CAPNP_INIT_FACTORIES>
+
+<CAPNP_RESTORE_FACTORIES>
+
    for (auto d : designMaker.objects_) {
     vpiHandle designH = uhdm_handleMaker.Make(uhdmdesign, d);
     designs.push_back(designH);
   }
-   
-  close(fileid); 
+
+  close(fileid);
   return designs;
 }


### PR DESCRIPTION
Remove trailing whitespaces in the process.