### PR TITLE
vpi_visitor: Use less stack.

### DIFF
--- a/templates/vpi_visitor.h
+++ b/templates/vpi_visitor.h
@@ -33,6 +33,10 @@
 
 namespace UHDM {
 
+// Visit designs, dump to given stream.
+void visit_designs (const std::vector<vpiHandle>& designs, std::ostream &out);
+
+// Visit designs, return string representation.
 std::string visit_designs (const std::vector<vpiHandle>& designs);
 
 };


### PR DESCRIPTION
The visit_object function was using > 350kiB stack due to
a lot of local string operations and temporary strings
also resulted in larger run time.

Changed to use streams; now < 16kiB stack usage and
possibly a lot faster.

Signed-off-by: Henner Zeller <h.zeller@acm.org>