### PR TITLE
Issue #210: Fix serialization crash on windows

### DIFF
--- a/templates/Serializer_restore.cpp
+++ b/templates/Serializer_restore.cpp
@@ -34,6 +34,7 @@
   #pragma warning(disable : 4244)  // 'argument' : conversion from 'type1' to 'type2', possible loss of data
 #else
   #include <unistd.h>
+  #define O_BINARY 0
 #endif
 
 #include <vector>

--- a/templates/Serializer_restore.cpp
+++ b/templates/Serializer_restore.cpp
@@ -54,7 +54,7 @@ using namespace UHDM;
 const std::vector<vpiHandle> Serializer::Restore(const std::string& file) {
   Purge();
   std::vector<vpiHandle> designs;
-  int fileid = open(file.c_str(), O_RDONLY);
+  int fileid = open(file.c_str(), O_RDONLY | O_BINARY);
   ::capnp::ReaderOptions options;
   options.traversalLimitInWords = ULLONG_MAX;
   options.nestingLimit = 1024;

--- a/templates/Serializer_save.cpp
+++ b/templates/Serializer_save.cpp
@@ -92,7 +92,7 @@ void Serializer::Purge() {
 }
 
 void Serializer::Save(std::string file) {
-  int fileid = open(file.c_str(), O_CREAT | O_WRONLY , S_IRWXU);
+  int fileid = open(file.c_str(), O_CREAT | O_WRONLY | O_BINARY, S_IRWXU);
   ::capnp::MallocMessageBuilder message;
   UhdmRoot::Builder cap_root = message.initRoot<UhdmRoot>();
   unsigned long index = 0;

--- a/templates/Serializer_save.cpp
+++ b/templates/Serializer_save.cpp
@@ -34,6 +34,7 @@
   #pragma warning(disable : 4267)  // 'var' : conversion from 'size_t' to 'type', possible loss of data
 #else
   #include <unistd.h>
+  #define O_BINARY 0
 #endif
 
 #include <vector>

--- a/tests/test_listener.cpp
+++ b/tests/test_listener.cpp
@@ -12,8 +12,9 @@ class MyVpiListener : public VpiListener {
 protected:
   void enterModule(const module* object, const BaseClass* parent,
                    vpiHandle handle, vpiHandle parentHandle) override {
+    const char* const parentName = vpi_get_str(vpiName, parentHandle);
     std::cout << "Module: " << object->VpiName()
-              << ", parent: " << vpi_get_str(vpiName, parentHandle)
+              << ", parent: " << ((parentName != nullptr) ? parentName : "")
               << std::endl;
     stack_.push(object);
   }
@@ -25,8 +26,9 @@ protected:
 
   void enterProgram(const program* object, const BaseClass* parent,
                     vpiHandle handle, vpiHandle parentHandle) override {
+    const char* const parentName = vpi_get_str(vpiName, parentHandle);
     std::cout << "Program: " << object->VpiName()
-              << ", parent: " << vpi_get_str(vpiName, parentHandle)
+              << ", parent: " << ((parentName != nullptr) ? parentName : "")
               << std::endl;
     stack_.push(object);
   }


### PR DESCRIPTION
Issue #210: Fixed serialization crash on windows.
Final commit to get things working on Windows.

Highlights -
* Open the file for serialization in binary mode (default on windows
  happens to be text). Be explicit.
* Passing a null pointer to an output stream is ambigious.

  Section [2003: 27.6.2.5.4]:
  template<class traits>
  basic_ostream<char,traits>& operator<<(basic_ostream<char,traits>& out, const char* s);
  3. Requires: 2 is non-null.

With this commit Windows builds are fully functional with all tests
passing.