### PR TITLE
Make uhdm-dump a toplevel utility binary.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,9 @@ add_dependencies(GenerateCode capnpc capnp_tool capnpc_cpp)
 
 if (UHDM_BUILD_TESTS)
   enable_testing()
+  # All unit-tests are registered with this custom target as dependency, so
+  # just `make UnitTests` will build them all.
+  add_custom_target(UnitTests)
 
   function(register_tests)
     foreach(test_cc_file IN LISTS ARGN)
@@ -163,8 +166,11 @@ if (UHDM_BUILD_TESTS)
       add_executable(${test_bin} ${PROJECT_SOURCE_DIR}/${test_cc_file})
       target_link_libraries(${test_bin} PRIVATE uhdm)
       add_test(
-	NAME ${test_prefix}/${test_bin} COMMAND ${test_bin}
-	WORKING_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+        NAME ${test_prefix}/${test_bin} COMMAND ${test_bin}
+        WORKING_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+
+      # Now, add this binary to our UnitTests target that it builds this
+      add_dependencies(UnitTests ${test_bin})
     endforeach()
   endfunction()
   register_tests(
@@ -175,15 +181,19 @@ if (UHDM_BUILD_TESTS)
     tests/test_tf_call.cpp
     tests/test_process.cpp
     tests/test_listener.cpp
-    tests/dump.cpp
+    tests/test-dump.cpp
     tests/listener_elab.cpp
     tests/full_elab.cpp
   )
 endif()
 
+# A debugging binary
+add_executable(uhdm-dump ${PROJECT_SOURCE_DIR}/util/uhdm-dump.cpp)
+target_link_libraries(uhdm-dump PRIVATE uhdm)
+
 # Installation target
 install(
-  TARGETS uhdm capnp kj
+  TARGETS uhdm capnp kj uhdm-dump
   ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/uhdm
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/include/uhdm)
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ if (UHDM_BUILD_TESTS)
   )
 endif()
 
-# A debugging binary
+# A useful utility
 add_executable(uhdm-dump ${PROJECT_SOURCE_DIR}/util/uhdm-dump.cpp)
 target_link_libraries(uhdm-dump PRIVATE uhdm)
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ debug:
 	$(MAKE) -C build
 
 test: build
-	$(MAKE) -C build test
+	$(MAKE) -C build UnitTests test
 
 test-junit: release
 	cd build && ctest --no-compress-output -T Test -C RelWithDebInfo --output-on-failure

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Universal Hardware Data Model
    * The listener enables client application development with minimum disruption while the data model evolves.
    * An Custom Elaborator example code uses the Listener Design Pattern in [`listener_elab.cpp`](tests/listener_elab.cpp)
    * A Full Elaboration example is demostrated in [`full_elab.cpp`](tests/full_elab.cpp) and [`dump.cpp`](tests/dump.cpp)
- * The uhdm-dump [`dump.cpp`](tests/dump.cpp) executable creates a human readable view of the UHDM serialized data model using the visitor [`visitor.cpp`](templates/vpi_visitor.cpp) 
+ * The uhdm-dump [`uhdm-dump`](util/uhdm-dump.cpp) executable creates a human readable view of the UHDM serialized data model using the visitor [`visitor.cpp`](templates/vpi_visitor.cpp).
 
 
 # Linking libuhdm.a to your application

--- a/tests/test-dump.cpp
+++ b/tests/test-dump.cpp
@@ -1,5 +1,5 @@
 /*
- * simple dump test. Simplified from src/uhdm-dump.cpp
+ * simple dump test. Simplified from util/uhdm-dump.cpp
  */
 #include <iostream>
 #include <sys/stat.h>

--- a/tests/test-dump.cpp
+++ b/tests/test-dump.cpp
@@ -1,0 +1,81 @@
+/*
+ * simple dump test. Simplified from src/uhdm-dump.cpp
+ */
+#include <iostream>
+#include <sys/stat.h>
+#include <string.h>
+#include <limits.h> /* PATH_MAX */
+#include <errno.h>
+#include <stdlib.h>
+#include <iostream>
+#include <algorithm>
+#include <string>
+#include <stdio.h>
+#include <regex>
+#include <fstream>
+#include <sstream>
+
+#if !(defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__))
+  #include <dirent.h>
+  #include <unistd.h>
+#endif
+
+#include "headers/uhdm.h"
+#include "headers/vpi_listener.h"
+#include "headers/vpi_visitor.h"
+#include "headers/ElaboratorListener.h"
+
+using namespace UHDM;
+
+static int usage(const char *progname) {
+  fprintf(stderr, "Usage %s: see uhdm-dump. This is a reduce test binary\n",
+          progname);
+  return 1;
+}
+
+int main (int argc, char** argv) {
+  bool elab = true;
+  bool verbose = true;
+  std::string uhdmFile;
+
+  // Simple option parsing that works on all platforms.
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    // Also supporting legacy long option with single dash
+    if (arg == "-elab" || arg == "--elab") elab = true;
+    else if (arg == "--verbose") verbose = true;
+    else if (uhdmFile.empty()) uhdmFile = arg;
+    else return usage(argv[0]);
+  }
+
+  if (uhdmFile.empty()) {
+    uhdmFile = "surelog.uhdm";   // used by default in test.
+  }
+
+  struct stat buffer;
+  if (stat(uhdmFile.c_str(), &buffer) != 0) {
+    std::cerr << uhdmFile << ": File does not exist!" << std::endl;
+    return usage(argv[0]);
+  }
+
+  Serializer serializer;
+  if (verbose) std::cerr << uhdmFile << ": restoring from file" << std::endl;
+  std::vector<vpiHandle> restoredDesigns = serializer.Restore(uhdmFile);
+
+  if (restoredDesigns.empty()) {
+    std::cerr << uhdmFile << ": empty design." << std::endl;
+    return 1;
+  }
+
+  std::cout << uhdmFile << ": Restored design Pre-Elab: " << std::endl;
+  visit_designs(restoredDesigns, std::cout);
+
+  if (elab) {
+    ElaboratorListener* listener = new ElaboratorListener(&serializer, false);
+    listen_designs(restoredDesigns, listener);
+    std::cout << uhdmFile << ": Restored design Post-Elab: " << std::endl;
+    visit_designs(restoredDesigns, std::cout);
+  }
+
+  return 0;
+};

--- a/util/uhdm-dump.cpp
+++ b/util/uhdm-dump.cpp
@@ -1,20 +1,37 @@
-#include <iostream>
-#include <sys/stat.h>
-#include <string.h>
-#include <limits.h> /* PATH_MAX */
+/*
+ * Copyright 2019 Alain Dargelas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <errno.h>
-#include <stdlib.h>
-#include <iostream>
-#include <algorithm>
-#include <string>
+#include <limits.h> /* PATH_MAX */
 #include <stdio.h>
-#include <regex>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include <algorithm>
 #include <fstream>
+#include <iostream>
+#include <regex>
 #include <sstream>
+#include <string>
+
 
 #if !(defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__))
-  #include <dirent.h>
-  #include <unistd.h>
+#  include <dirent.h>
+#  include <unistd.h>
 #endif
 
 #include "headers/uhdm.h"
@@ -54,8 +71,9 @@ static bool CompareContentWithFile(const std::string &content,
 
 static int usage(const char *progname) {
   fprintf(stderr, "Usage:\n%s [options] <uhdm-file> [<golden-file-to-compare>]\n", progname);
-  fprintf(stderr, "Reads UHDM binary representation and prints tree. If --elab is given, the\n"
-          "tree is elaborated first.\n");
+  fprintf(stderr,
+          "Reads UHDM binary representation and prints tree. If --elab is "
+          "given, the\ntree is also elaborated.\n");
   fprintf(stderr, "Options:\n"
           "\t--elab          : Elaborate the restored design.\n"
           "\t--verbose       : print diagnostic messages.\n"
@@ -63,7 +81,7 @@ static int usage(const char *progname) {
   return 1;
 }
 
-int main (int argc, char** argv) {
+int main(int argc, char** argv) {
   bool elab = false;
   bool verbose = false;
   std::string uhdmFile;
@@ -81,7 +99,7 @@ int main (int argc, char** argv) {
   }
 
   if (uhdmFile.empty()) {
-    uhdmFile = "surelog.uhdm";
+    return usage(argv[0]);
   }
 
   struct stat buffer;


### PR DESCRIPTION
Dumping uhdm is a critical part of working with uhdm, so
let's make this a toplevel binary, installed in $PREFIX/bin/uhdm-dump.

Previously, the testing binary used in tests/dump.cpp was used for that,
but let's keep that just a simple round-trip test.

Additional context: not only makes it sense in this context, but also
in Surelog, in which we'd like to disable building UDHM tests, but still
need a binary to dump uhdm.

Signed-off-by: Henner Zeller <h.zeller@acm.org>