### PR TITLE
Remove trailing spaces and fix some smallish indentation.

### DIFF
--- a/model_gen/generate_elaborator.tcl
+++ b/model_gen/generate_elaborator.tcl
@@ -37,19 +37,19 @@ proc generate_elaborator { models } {
 
         append clone_cases "  case $vpiName: {
 "
-        
+
         if [regexp {Net} $vpiName] {
             append clone_cases "    $classname* clone_obj = dynamic_cast<$classname*>(elaborator->bindNet((($classname*)root)->VpiName()));
     if (clone_obj == nullptr) {
       clone_obj = s.Make${Classname}();
-    } 
-"   
+    }
+"
         } elseif [regexp {Parameter} $vpiName] {
             append clone_cases "    $classname* clone_obj = dynamic_cast<$classname*>(elaborator->bindParam((($classname*)root)->VpiName()));
     if (clone_obj == nullptr) {
       clone_obj = s.Make${Classname}();
-    } 
-"   
+    }
+"
         } else {
             append clone_cases "    $classname* clone_obj = s.Make${Classname}();
 "
@@ -67,7 +67,7 @@ proc generate_elaborator { models } {
             set Classname [string toupper $classname 0 0]
             set modeltype [dict get $data type]
             set MODEL_TYPE($classname) $modeltype
-            
+
             dict for {key val} $data {
                 if {$key == "properties"} {
                     dict for {prop conf} $val {
@@ -96,7 +96,7 @@ proc generate_elaborator { models } {
                                 append method "s"
                             }
                         }
-                        
+
                         if {$card == 1} {
                             append clone_cases "    clone_obj->${method}((${cast}*) clone_tree((($classname*)root)->${method}(), s, elaborator));
 "
@@ -105,15 +105,15 @@ proc generate_elaborator { models } {
                                     append clone_cases "    if (clone_obj->${method}() == nullptr) {
       clone_obj->${method}(elaborator->bindAny((($classname*)root)->VpiName()));
     }
-"  
-                                } 
+"
+                                }
                             }
-                            
+
                             if {$rootclassname == "module"} {
                                 append vpi_listener "          inst->${method}((${cast}*) clone_tree(defMod->${method}(), *serializer_, this));
 "
                             }
-                        } else {                          
+                        } else {
                             append clone_cases "    if (auto vec = (($classname*)root)->${method}()) {
       auto clone_vec = s.Make${Cast}Vec();
       clone_obj->${method}(clone_vec);
@@ -132,8 +132,8 @@ proc generate_elaborator { models } {
             }
           }
 "
-                                
-                            }  
+
+                            }
                         }
                     }
                 }
@@ -145,33 +145,33 @@ proc generate_elaborator { models } {
             } else {
                 set baseclass ""
             }
-            
-            
+
+
         }
 
         append clone_cases "    break;
   }
 "
- 
-   
+
+
     }
 
-    
+
     set fid [open "[project_path]/templates/ElaboratorListener.h"]
     set listener_content [read $fid]
     close $fid
-    
+
     regsub {<ELABORATOR_LISTENER>} $listener_content $vpi_listener listener_content
 
     set listenerId [open "[project_path]/headers/ElaboratorListener.h" "w"]
     puts $listenerId $listener_content
     close $listenerId
 
-    
+
     set fid [open "[project_path]/templates/clone_tree.h"]
     set clone_content [read $fid]
     close $fid
-    
+
     set cloneId [open "[project_path]/headers/clone_tree.h" "w"]
     puts $cloneId $clone_content
     close $cloneId
@@ -179,11 +179,11 @@ proc generate_elaborator { models } {
     set fid [open "[project_path]/templates/clone_tree.cpp"]
     set clone_content [read $fid]
     close $fid
-    
+
     regsub {<CLONE_CASES>} $clone_content $clone_cases clone_content
 
     set cloneId [open "[project_path]/src/clone_tree.cpp" "w"]
     puts $cloneId $clone_content
     close $cloneId
-    
+
 }

--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -121,16 +121,16 @@ proc printMethods { classname type vpi card {real_type ""} } {
             append methods "\n    ${virtual}bool [string toupper ${vpi} 0 0](const ${type}${pointer}\\& data)$final;\n"
             if {$vpi == "vpiFullName" } {
                 append methods "\n    ${virtual}const ${type}${pointer}\\&  [string toupper ${vpi} 0 0]() const$final;\n"
-                append methods_cpp "\nconst ${type}${pointer}\\&  ${classname}::[string toupper ${vpi} 0 0]() const { 
+                append methods_cpp "\nconst ${type}${pointer}\\&  ${classname}::[string toupper ${vpi} 0 0]() const {
   if (${vpi}_) {
-    return serializer_->symbolMaker.GetSymbol(${vpi}_); 
+    return serializer_->symbolMaker.GetSymbol(${vpi}_);
   } else {
     std::vector<std::string> names;
     const BaseClass* parent = this;
     while (parent) {
       if (parent->UhdmType() == uhdmdesign) break;
       const std::string\\& name = (parent->VpiName() != \"\") ? parent->VpiName() : parent->VpiDefName();
-      if (name != \"\") 
+      if (name != \"\")
         names.push_back(name);
       parent = parent->VpiParent();
     }
@@ -143,14 +143,14 @@ proc printMethods { classname type vpi card {real_type ""} } {
         if (index == 0) break;
         index--;
       }
-    }  
+    }
     ((${classname}*)this)->VpiFullName(fullName);
-    return serializer_->symbolMaker.GetSymbol(${vpi}_); 
+    return serializer_->symbolMaker.GetSymbol(${vpi}_);
   }
 }\n"
             } else {
-             append methods "\n    ${virtual}const ${type}${pointer}\\& [string toupper ${vpi} 0 0]() const$final;\n"
-             append methods_cpp "\nconst ${type}${pointer}\\& ${classname}::[string toupper ${vpi} 0 0]() const { return serializer_->symbolMaker.GetSymbol(${vpi}_); }\n"
+                append methods "\n    ${virtual}const ${type}${pointer}\\& [string toupper ${vpi} 0 0]() const$final;\n"
+                append methods_cpp "\nconst ${type}${pointer}\\& ${classname}::[string toupper ${vpi} 0 0]() const { return serializer_->symbolMaker.GetSymbol(${vpi}_); }\n"
             }
             append methods_cpp "\nbool ${classname}::[string toupper ${vpi} 0 0](const ${type}${pointer}\\& data) { ${vpi}_ = serializer_->symbolMaker.Make(data); return true; }\n"
         } else {
@@ -392,7 +392,7 @@ proc printGetStrBody {classname type vpi card} {
             append vpi_get_str_body "
   if (handle->type == uhdm${classname}) {
     if (property == $vpi) {
-      if (((($classname*)(obj))->[string toupper ${vpi} 0 0]() == \"\") || ((($classname*)(obj))->[string toupper ${vpi} 0 0]() == (($classname*)(obj))->VpiName())) { 
+      if (((($classname*)(obj))->[string toupper ${vpi} 0 0]() == \"\") || ((($classname*)(obj))->[string toupper ${vpi} 0 0]() == (($classname*)(obj))->VpiName())) {
         return 0;
       } else {
         return (PLI_BYTE8*) (($classname*)(obj))->[string toupper ${vpi} 0 0]().c_str();
@@ -404,7 +404,7 @@ proc printGetStrBody {classname type vpi card} {
             append vpi_get_str_body "
   if (handle->type == uhdm${classname}) {
     if (property == $vpi) {
-      if ((($classname*)(obj))->[string toupper ${vpi} 0 0]() == \"\") { 
+      if ((($classname*)(obj))->[string toupper ${vpi} 0 0]() == \"\") {
         return 0;
       } else {
         return (PLI_BYTE8*) (($classname*)(obj))->[string toupper ${vpi} 0 0]().c_str();
@@ -513,9 +513,9 @@ proc printVpiVisitor {classname vpi card} {
         }
     }
 
-   if {($vpi == "vpiParent") && ($classname !="part_select")} {
-      return
-   }
+    if {($vpi == "vpiParent") && ($classname !="part_select")} {
+        return
+    }
 
     if {$card == 1} {
         # Prevent loop in Standard VPI
@@ -531,7 +531,7 @@ proc printVpiVisitor {classname vpi card} {
         }
         # Prevent loop in Standard VPI
         if {$vpi != "vpiUse"} {
-        append vpi_visitor "    itr = vpi_iterate($vpi,obj_h);
+            append vpi_visitor "    itr = vpi_iterate($vpi,obj_h);
     while (vpiHandle obj = vpi_scan(itr) ) {
       visit_object(obj, subobject_indent, \"$vpi\", visited, out);
     }
@@ -754,164 +754,164 @@ proc write_VpiListener_h {} {
 }
 
 set SHORT_VISITOR_LIST { class_obj
-assertion
-immediate_assert
-tchk_term
-primitive
-clocked_property
-enum_const
-attribute
-task_call
-parameter
-program_array
-chandle_var
-return_stmt
-switch_array
-cont_assign
-while_stmt
-property_typespec
-fork_stmt
-repeat
-assert_stmt
-logic_typespec
-property_inst
-gen_var
-bit_typespec
-packed_array_net
-byte_var
-break_stmt
-sys_func_call
-typespec
-modport
-enum_var
-event_typespec
-named_event
-int_typespec
-forever_stmt
-interface_tf_decl
-final_stmt
-repeat_control
-packed_array_typespec
-port_bit
-short_real_var
-let_decl
-immediate_assume
-union_typespec
-param_assign
-integer_var
-method_func_call
-user_systf
-prim_term
-string_var
-property_spec
-delay_control
-expect_stmt
-operation
-class_typespec
-short_int_var
-event_control
-case_item
-gen_scope
-path_term
-property_decl
-assign_stmt
-tf_call
-sequence_typespec
-net_bit
-udp_defn
-short_int_typespec
-function
-sequence_inst
-delay_term
-named_fork
-time_var
-byte_typespec
-ports
-distribution
-initial
-string_typespec
-int_var
-do_while
-case_stmt
-sys_task_call
-package
-mod_path
-real_var
-atomic_stmt
-if_stmt
-virtual_interface_var
-if_else
-foreach_stmt
-alias_stmt
-release
-type_parameter
-class_defn
-null_stmt
-time_typespec
-enum_net
-module_array
-continue_stmt
-method_task_call
-task_func
-packed_array_var
-for_stmt
-func_call
-def_param
-array_var
-force
-scope
-typespecs
-sequence_decl
-named_begin
-spec_param
-instance_array
-integer_net
-reg_array
-constraint
-interface_typespec
-begin
-void_typespec
-cont_assign_bit
-class_var
-deassign
-udp_array
-gate_array
-unsupported_expr
-real_typespec
-program
-unsupported_stmt
-union_var
-always
-gen_scope_array
-integer_typespec
-tchk
-long_int_var
-array_typespec
-task
-named_event_array
-clocking_block
-time_net
-multiclock_sequence_expr
-concurrent_assertions
-immediate_cover
-long_int_typespec
-short_real_typespec
-primitive_array
-interface_array
-io_decl
-var_bit
-bit_var
-design
+    assertion
+    immediate_assert
+    tchk_term
+    primitive
+    clocked_property
+    enum_const
+    attribute
+    task_call
+    parameter
+    program_array
+    chandle_var
+    return_stmt
+    switch_array
+    cont_assign
+    while_stmt
+    property_typespec
+    fork_stmt
+    repeat
+    assert_stmt
+    logic_typespec
+    property_inst
+    gen_var
+    bit_typespec
+    packed_array_net
+    byte_var
+    break_stmt
+    sys_func_call
+    typespec
+    modport
+    enum_var
+    event_typespec
+    named_event
+    int_typespec
+    forever_stmt
+    interface_tf_decl
+    final_stmt
+    repeat_control
+    packed_array_typespec
+    port_bit
+    short_real_var
+    let_decl
+    immediate_assume
+    union_typespec
+    param_assign
+    integer_var
+    method_func_call
+    user_systf
+    prim_term
+    string_var
+    property_spec
+    delay_control
+    expect_stmt
+    operation
+    class_typespec
+    short_int_var
+    event_control
+    case_item
+    gen_scope
+    path_term
+    property_decl
+    assign_stmt
+    tf_call
+    sequence_typespec
+    net_bit
+    udp_defn
+    short_int_typespec
+    function
+    sequence_inst
+    delay_term
+    named_fork
+    time_var
+    byte_typespec
+    ports
+    distribution
+    initial
+    string_typespec
+    int_var
+    do_while
+    case_stmt
+    sys_task_call
+    package
+    mod_path
+    real_var
+    atomic_stmt
+    if_stmt
+    virtual_interface_var
+    if_else
+    foreach_stmt
+    alias_stmt
+    release
+    type_parameter
+    class_defn
+    null_stmt
+    time_typespec
+    enum_net
+    module_array
+    continue_stmt
+    method_task_call
+    task_func
+    packed_array_var
+    for_stmt
+    func_call
+    def_param
+    array_var
+    force
+    scope
+    typespecs
+    sequence_decl
+    named_begin
+    spec_param
+    instance_array
+    integer_net
+    reg_array
+    constraint
+    interface_typespec
+    begin
+    void_typespec
+    cont_assign_bit
+    class_var
+    deassign
+    udp_array
+    gate_array
+    unsupported_expr
+    real_typespec
+    program
+    unsupported_stmt
+    union_var
+    always
+    gen_scope_array
+    integer_typespec
+    tchk
+    long_int_var
+    array_typespec
+    task
+    named_event_array
+    clocking_block
+    time_net
+    multiclock_sequence_expr
+    concurrent_assertions
+    immediate_cover
+    long_int_typespec
+    short_real_typespec
+    primitive_array
+    interface_array
+    io_decl
+    var_bit
+    bit_var
+    design
 }
 
 
 proc write_vpi_visitor_cpp {} {
-    global VISITOR VISITOR_RELATIONS SHORT_VISITOR_LIST 
+    global VISITOR VISITOR_RELATIONS SHORT_VISITOR_LIST
 
     foreach item $SHORT_VISITOR_LIST {
         set filter($item) 1
     }
-    
+
     set fid [open "[project_path]/templates/vpi_visitor.cpp"]
     set visitor_cpp [read $fid]
     close $fid
@@ -1264,7 +1264,7 @@ proc generate_code { models } {
                     regsub -all  {_} $Vpi "" Vpi
                     if {$type == "string" || $type == "value" || $type == "delay"} {
                         if {$Vpi != "VpiFullName"} {
-                          append SAVE($classname) "    ${Classname}s\[index\].set${Vpi}(obj->GetSerializer()->symbolMaker.Make(obj->[string toupper ${vpi} 0 0]()));\n"
+                            append SAVE($classname) "    ${Classname}s\[index\].set${Vpi}(obj->GetSerializer()->symbolMaker.Make(obj->[string toupper ${vpi} 0 0]()));\n"
                             append RESTORE($classname) "    ${classname}Maker.objects_\[index\]->[string toupper ${vpi} 0 0](symbolMaker.GetSymbol(obj.get${Vpi}()));\n"
                         }
                     } else {
@@ -1460,9 +1460,9 @@ proc generate_code { models } {
     set capnp_path [file dirname $capnp_path]
 
     if { $tcl_platform(platform) == "windows" } {
-      exec cmd /c "set PATH=$capnp_path;%PATH%; && cd /d [project_path]/src && $capnp_path/capnp.exe compile -oc++ UHDM.capnp"
+        exec cmd /c "set PATH=$capnp_path;%PATH%; && cd /d [project_path]/src && $capnp_path/capnp.exe compile -oc++ UHDM.capnp"
     } else {
-      exec sh -c "export PATH=$capnp_path; $capnp_path/capnp compile -oc++:. [project_path]/src/UHDM.capnp"
+        exec sh -c "export PATH=$capnp_path; $capnp_path/capnp compile -oc++:. [project_path]/src/UHDM.capnp"
     }
 
     # BaseClass.h

--- a/model_gen/vpi_reverse_map.tcl
+++ b/model_gen/vpi_reverse_map.tcl
@@ -50,5 +50,3 @@ proc write_enum { file } {
 parse_define_file "../include/vpi_user.h"
 parse_define_file "../include/sv_vpi_user.h"
 write_enum "vpi_map.txt"
-
-


### PR DESCRIPTION
No semantic code changes, just whitespaces.

This is a baseline so that future changes don't look cluttered
with random lines changed.
This is the result of the .editorconfig trim_trailing_whitespace
configuration applied.

Signed-off-by: Henner Zeller <h.zeller@acm.org>