### PR TITLE
vpi_user: handle some properties from the base-class once.

### DIFF
--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -129,8 +129,8 @@ proc printMethods { classname type vpi card {real_type ""} } {
     const BaseClass* parent = this;
     while (parent) {
       if (parent->UhdmType() == uhdmdesign) break;
-      const std::string\\& name = (parent->VpiName() != \"\") ? parent->VpiName() : parent->VpiDefName();
-      if (name != \"\")
+      const std::string\\& name = (!parent->VpiName().empty()) ? parent->VpiName() : parent->VpiDefName();
+      if (!name.empty())
         names.push_back(name);
       parent = parent->VpiParent();
     }
@@ -275,15 +275,27 @@ proc printGetHandleByNameBody { name classname vpi card } {
     return $vpi_handle_by_name_body
 }
 
+proc printGetBodyPrefix {classname} {
+    return "  else if (handle->type == uhdm${classname}) \{
+    switch (property) \{"
+}
+
+proc printGetBodySuffix {} {
+    return "
+    \}
+  \}
+"
+}
+
 proc printGetBody {classname type vpi card} {
+    # These are already handled by base class
+    if {$vpi == "vpiType"} return ""
+    if {$vpi == "vpiLineNo"} return ""
+
     set vpi_get_body ""
     if {($card == 1) && ($type != "string") && ($type != "value") && ($type != "delay")} {
         append vpi_get_body "
-  if (handle->type == uhdm${classname}) {
-    if (property == $vpi) {
-      return (($classname*)(obj))->[string toupper ${vpi} 0 0]();
-    }
-  }"
+      case $vpi: return ((const $classname*)(obj))->[string toupper ${vpi} 0 0]();"
     }
     return $vpi_get_body
 }
@@ -364,7 +376,7 @@ proc printGetVisitor {classname type vpi card} {
     vpi_get_value(obj_h, \\&value);
     if (value.format) {
       std::string val = visit_value(\\&value);
-      if (val != \"\") {
+      if (!val.empty()) {
         stream_indent(out, indent) << val;
       }
     }
@@ -386,32 +398,27 @@ proc printGetVisitor {classname type vpi card} {
 }
 
 proc printGetStrBody {classname type vpi card} {
+    # Already handled by the base class
+    if {$vpi == "vpiFile"} return ""
+    if {$vpi == "vpiName"} return ""
+    if {$vpi == "vpiDefName"} return ""
+
     set vpi_get_str_body ""
     if {$card == 1 && ($type == "string")} {
         if {$vpi == "vpiFullName"} {
             append vpi_get_str_body "
-  if (handle->type == uhdm${classname}) {
-    if (property == $vpi) {
-      if (((($classname*)(obj))->[string toupper ${vpi} 0 0]() == \"\") || ((($classname*)(obj))->[string toupper ${vpi} 0 0]() == (($classname*)(obj))->VpiName())) {
-        return 0;
-      } else {
-        return (PLI_BYTE8*) (($classname*)(obj))->[string toupper ${vpi} 0 0]().c_str();
-      }
-    }
-  }
-"
+  else if (handle->type == uhdm${classname} \\&\\& property == $vpi) {
+    const $classname* const o = (const $classname*)(obj);
+    return (o->[string toupper ${vpi} 0 0]().empty() || o->[string toupper ${vpi} 0 0]() == o->VpiName())
+        ? 0
+        : (PLI_BYTE8*) o->[string toupper ${vpi} 0 0]().c_str();
+  }"
         } else {
             append vpi_get_str_body "
-  if (handle->type == uhdm${classname}) {
-    if (property == $vpi) {
-      if ((($classname*)(obj))->[string toupper ${vpi} 0 0]() == \"\") {
-        return 0;
-      } else {
-        return (PLI_BYTE8*) (($classname*)(obj))->[string toupper ${vpi} 0 0]().c_str();
-      }
-    }
-  }
-"
+  else if (handle->type == uhdm${classname} \\&\\& property == $vpi) {
+    const $classname* const o = (const $classname*)(obj);
+    return (PLI_BYTE8*) (o->[string toupper ${vpi} 0 0]().empty() ? 0 : o->[string toupper ${vpi} 0 0]().c_str());
+  }"
         }
     }
     return $vpi_get_str_body
@@ -1013,8 +1020,18 @@ proc update_vpi_inst { baseclass classname lvl } {
         }
     }
     if [info exist vpi_get_body_inst_l($baseclass)] {
+
+        set vpi_case_body ""
         foreach inst $vpi_get_body_inst_l($baseclass) {
-            append vpi_get_body_l [printGetBody $classname [lindex $inst 1] [lindex $inst 2] [lindex $inst 3]]
+            append vpi_case_body [printGetBody $classname [lindex $inst 1] [lindex $inst 2] [lindex $inst 3]]
+        }
+        # The case body can be empty if all propeerties have been handled
+        # in the base class. So only if non-empty, add the if/switch
+        if {$vpi_case_body != ""} {
+            append vpi_get_body_l [printGetBodyPrefix $classname] $vpi_case_body [printGetBodySuffix]
+        }
+
+        foreach inst $vpi_get_body_inst_l($baseclass) {
             append vpi_get_value_body_l [printGetValueBody $classname [lindex $inst 1] [lindex $inst 2] [lindex $inst 3]]
             append vpi_get_delay_body_l [printGetDelayBody $classname [lindex $inst 1] [lindex $inst 2] [lindex $inst 3]]
             append VISITOR($classname) [printGetVisitor $classname [lindex $inst 1] [lindex $inst 2] [lindex $inst 3]]


### PR DESCRIPTION
The base class offers a few properties, such as VpiLineNo() or
VpiFile() that can be handled once in vpi_get() and vpi_get_str(),
so that the remaining function body only has to worry about the
'non-standard' properties.

 * Changed vpi_get64()/vpi_get() to handle VpiLineNo() and VpiType().
 * All other properties are output in a similar way as before,
   but in a slightly easier human-browsable switch/case form.
 * Since get64 and get are the same right now, just one one function
   call the other so that we don't duplicate code.
 * vpi_get_str handles VpiFile, VpiName and VpiDefName from the
   base-class, then deals with remaining 'manually'.

There are still a lot of properties that have to be handled
manually, but future work could consider having property-specific
interfaces ('VpiFullNamePropertyContainer') that could further
reduce that.

Also, other parts of the code generation have not been adressed yet, but something like
this might help in the future minimize excessive compile times and improve runtime.

Overall, this reduces the number of branches the compiler has to
encode and the runtime has to consider a lot. Dumping BlackParrot2
got 20% faster.

I verified that the `uhdm-dump` output for Blackparrot2 is identical of the before/after code generator change.

##### Before

```c++
PLI_INT32 vpi_get (PLI_INT32   property,
                   vpiHandle   object) {
  // [... ]

  if (handle->type == uhdmattribute) {
    if (property == vpiLineNo) {
      return ((attribute*)(obj))->VpiLineNo();
    }
  }
  if (handle->type == uhdmattribute) {
    if (property == vpiDefAttribute) {
      return ((attribute*)(obj))->VpiDefAttribute();
    }
  }
  if (handle->type == uhdmattribute) {
    if (property == vpiDefLineNo) {
      return ((attribute*)(obj))->VpiDefLineNo();
    }
  }
  if (handle->type == uhdmattribute) {
    if (property == vpiType) {
      return ((attribute*)(obj))->VpiType();
    }
  }
//...
```

##### After

Note that `vpiLineNo` and `vpiType` don't have to be handled in the other types. Some times only would provide
these properties, they don't even show up anymore in the `if (...)` branches.
```c++
PLI_INT64 vpi_get64 (PLI_INT32 property,
                     vpiHandle   object) {
  // [...]

  // Baseclass-handled properties; all the others still need to be handled
  // separately, but this is a good start.
  switch (property) {
    case vpiLineNo: return obj->VpiLineNo();
    case vpiType: return obj->VpiType();
  }

  // ... all other properties currently handled 'manually' for now
  if (false) {}
  else if (handle->type == uhdmattribute) {
    switch (property) {
      case vpiDefAttribute: return ((const attribute*)(obj))->VpiDefAttribute();
      case vpiDefLineNo: return ((const attribute*)(obj))->VpiDefLineNo();
    }
  }
  else if (handle->type == uhdmconcurrent_assertions) {
    switch (property) {
      case vpiIsClockInferred: return ((const concurrent_assertions*)(obj))->VpiIsClockInferred();
    }
  }
 // [...]
  else if (handle->type == uhdmassertion) {
   switch (property) {
     case vpiStartLine: return ((const assertion*)(obj))->VpiStartLine();
     case vpiColumn: return ((const assertion*)(obj))->VpiColumn();
     case vpiEndLine: return ((const assertion*)(obj))->VpiEndLine();
     case vpiEndColumn: return ((const assertion*)(obj))->VpiEndColumn();
   }
  }
}
```

Signed-off-by: Henner Zeller <h.zeller@acm.org>