### PR TITLE
vpi_user: handle some properties from the base-class once.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ if (UHDM_BUILD_TESTS)
     tests/test-dump.cpp
     tests/listener_elab.cpp
     tests/full_elab.cpp
+    tests/vpi_get_test.cpp
   )
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ debug:
 	$(MAKE) -C build
 
 test: build
-	$(MAKE) -C build UnitTests test
+	$(MAKE) -C build UnitTests
+	cd build && ctest --output-on-failure
 
 test-junit: release
 	cd build && ctest --no-compress-output -T Test -C RelWithDebInfo --output-on-failure

--- a/templates/vpi_user.cpp
+++ b/templates/vpi_user.cpp
@@ -76,7 +76,7 @@ s_vpi_value* String2VpiValue(const std::string& s) {
     scopy.erase(0,5);
     val->format = vpiRealVal;
     val->value.real = atol(scopy.c_str());
-  } 
+  }
   return val;
 }
 
@@ -129,7 +129,7 @@ std::string VpiValue2String(const s_vpi_value* value) {
   case vpiRealVal: {
     return std::string(std::string("REAL:") + std::to_string(value->value.real));
     break;
-  }   
+  }
   default:
     break;
   }
@@ -196,6 +196,7 @@ vpiHandle vpi_handle_multi (PLI_INT32 type,
 vpiHandle vpi_iterate (PLI_INT32 type, vpiHandle refHandle) {
   const uhdm_handle* const handle = (const uhdm_handle*) refHandle;
   const BaseClass* const object = (const BaseClass*) handle->object;
+
   <VPI_ITERATE_BODY>
   std::cout << "VPI ERROR: Bad usage of vpi_iterate" << std::endl;
   return 0;
@@ -226,10 +227,10 @@ PLI_INT32 vpi_get (PLI_INT32   property,
       std::cout << "VPI ERROR: Bad usage of vpi_get" << std::endl;
     return 0;
   }
-  uhdm_handle* handle = (uhdm_handle*) object;
-  BaseClass*  obj = (BaseClass*) handle->object;
-  <VPI_GET_BODY>
-  return 0;
+
+  // At this point, the implementation is exactly the same as for 64 bit,
+  // but we truncate.
+  return (PLI_INT32) vpi_get64(property, object);
 }
 
 PLI_INT64 vpi_get64 (PLI_INT32 property,
@@ -238,9 +239,20 @@ PLI_INT64 vpi_get64 (PLI_INT32 property,
       std::cout << "VPI ERROR: Bad usage of vpi_get64" << std::endl;
     return 0;
   }
-  uhdm_handle* handle = (uhdm_handle*) object;
-  BaseClass*  obj = (BaseClass*) handle->object;
-  <VPI_GET_BODY>
+
+  const uhdm_handle* const handle = (const uhdm_handle*) object;
+  const BaseClass*  const obj = (const BaseClass*) handle->object;
+
+  // Baseclass-handled properties; all the others still need to be handled
+  // separately, but this is a good start.
+  switch (property) {
+    case vpiLineNo: return obj->VpiLineNo();
+    case vpiType: return obj->VpiType();
+  }
+
+  // ... all other properties currently handled 'manually' for now
+<VPI_GET_BODY>
+
   return 0;
 }
 
@@ -250,9 +262,32 @@ PLI_BYTE8 *vpi_get_str (PLI_INT32 property,
     std::cout << "VPI ERROR: Bad usage of vpi_get_str" << std::endl;
     return 0;
   }
-  uhdm_handle* handle = (uhdm_handle*) object;
-  BaseClass*  obj = (BaseClass*) handle->object;
+  const uhdm_handle* const handle = (const uhdm_handle*) object;
+  const BaseClass*  const obj = (const BaseClass*) handle->object;
+
+  // Handle some easy cases first; these are handled in the BaseClass.
+  // TODO: add some specific property interfaces (VpiFullNameImplementor?)
+  // to access some other common properties.
+  switch (property) {
+    case vpiFile:
+      return (PLI_BYTE8*) (obj->VpiFile().empty()
+                           ? 0
+                           : obj->VpiFile().c_str());
+
+   case vpiName:
+     return (PLI_BYTE8*) (obj->VpiName().empty()
+                          ? 0
+                          : obj->VpiName().c_str());
+
+    case vpiDefName:
+      return (PLI_BYTE8*) (obj->VpiDefName().empty()
+                           ? 0
+                           : obj->VpiDefName().c_str());
+  }
+
+  // ... all other properties currently handled 'manually' for now
   <VPI_GET_STR_BODY>
+
   return 0;
 }
 
@@ -264,8 +299,8 @@ void vpi_get_delays (vpiHandle object,
   if (!object) {
     std::cout << "VPI ERROR: Bad usage of vpi_get_delay" << std::endl;
   }
-  uhdm_handle* handle = (uhdm_handle*) object;
-  BaseClass*  obj = (BaseClass*) handle->object;
+  const uhdm_handle* const handle = (const uhdm_handle*) object;
+  const BaseClass*  const obj = (const BaseClass*) handle->object;
   delay_p->da = nullptr;
   <VPI_GET_DELAY_BODY>
 }
@@ -281,8 +316,8 @@ void vpi_get_value (vpiHandle vexpr,
   if (!vexpr) {
     std::cout << "VPI ERROR: Bad usage of vpi_get_value" << std::endl;
   }
-  uhdm_handle* handle = (uhdm_handle*) vexpr;
-  BaseClass*  obj = (BaseClass*) handle->object;
+  const uhdm_handle* const handle = (const uhdm_handle*) vexpr;
+  const BaseClass*  const obj = (const BaseClass*) handle->object;
   value_p->format = 0;
   <VPI_GET_VALUE_BODY>
 }

--- a/tests/test1.cpp
+++ b/tests/test1.cpp
@@ -97,7 +97,7 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
   m1->Instance_items(inst_items);
   MyPayLoad* pl = new MyPayLoad(10);
   m1->Data(pl);
-  
+
   vpiHandle dh = s.MakeUhdmHandle(uhdmdesign, d);
   designs.push_back(dh);
 
@@ -112,7 +112,7 @@ std::vector<vpiHandle> build_designs (Serializer& s) {
       exit(1);
     }
   }
-  
+
   return designs;
 }
 

--- a/tests/vpi_get_test.cpp
+++ b/tests/vpi_get_test.cpp
@@ -1,0 +1,42 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+
+#include <iostream>
+
+#include "headers/uhdm.h"
+#include "headers/constant.h"
+#include "headers/vpi_uhdm.h"     // struct uhdm_handle
+#include "include/vhpi_user.h"    // vpi_user functions.
+#include "headers/uhdm_types.h"   // for uhdmconstant
+
+#include <stdlib.h>
+
+#define EXPECT_TRUE(x) if ((x)) {} else { std::cerr << __LINE__ << ": " << #x << "\n"; abort(); }
+#define EXPECT_EQ(x, y) if ((x) == (y)) {} else { std::cerr << __LINE__ << ": " << #x << " == " << #y << "\n"; abort(); }
+
+int main() {
+  UHDM::Serializer serializer;
+
+  // Let's choose a type that is multiple levels deep to see levels
+  // base-class <- expr <- constant
+
+  UHDM::constant *value = serializer.MakeConstant();
+  // Base class values
+  EXPECT_TRUE(value->VpiFile("hello.v"));
+  EXPECT_TRUE(value->VpiLineNo(42));
+
+  // expr values
+  EXPECT_TRUE(value->VpiSize(12345));
+  EXPECT_TRUE(value->VpiDecompile("decompile"));
+
+  uhdm_handle uhdm_handle(UHDM::uhdmconstant, value);
+  vpiHandle vpi_handle = (vpiHandle) &uhdm_handle;
+
+  // Request all the properties set above via vpi
+  EXPECT_EQ(vpi_get_str(vpiFile, vpi_handle), std::string("hello.v"));
+  EXPECT_EQ(vpi_get(vpiLineNo, vpi_handle), 42);
+
+  EXPECT_EQ(vpi_get(vpiSize, vpi_handle), 12345);
+  EXPECT_EQ(vpi_get_str(vpiDecompile, vpi_handle), std::string("decompile"));
+
+  return 0;
+}


### PR DESCRIPTION
Redo of pull #274

Tested with Surelog: all regression tests pass.

The base class offers a few properties, such as VpiLineNo() or
VpiFile() that can be handled once in vpi_get() and vpi_get_str(),
so that the remaining function body only has to worry about the
'non-standard' properties.

 * Changed vpi_get64()/vpi_get() to handle VpiLineNo() and VpiType().
 * All other properties are output in a similar way as before,
   but in a slightly easier human-browsable switch/case form.
 * Since get64 and get are the same right now, just one one function
   call the other so that we don't duplicate code.
 * vpi_get_str handles VpiFile, VpiName and VpiDefName from the
   base-class, then deals with remaining 'manually'.

There are still a lot of properties that have to be handled
manually, but future work could consider having property-specific
interfaces ('VpiFullNamePropertyContainer') that could further
reduce that.

Overall, this reduces the number of branches the compiler has to
encode and the runtime has to consider a lot. Dumping BlackParrot2
got 20% faster.

Difference to the #274 is, that we don't if/else if through the
classes but if () each individually: apparently the same class name
is repeated multiple times in the list iterated through in the list
(separate problem independent of this change; to address separately).

Signed-off-by: Henner Zeller <h.zeller@acm.org>