### PR TITLE
Document NewHandle() memory-leak situation and path forward.

### DIFF
--- a/templates/vpi_listener.cpp
+++ b/templates/vpi_listener.cpp
@@ -42,10 +42,6 @@
 
 using namespace UHDM;
 
-static vpiHandle NewHandle (UHDM_OBJECT_TYPE type, const void *object) {
-  return reinterpret_cast<vpiHandle>(new uhdm_handle(type, object));
-}
-
 <VPI_LISTENERS>
 
 void UHDM::listen_any(vpiHandle object, VpiListener* listener) {
@@ -62,4 +58,3 @@ void UHDM::listen_designs (const std::vector<vpiHandle>& designs, VpiListener* l
     listen_design(design_h, listener);
   }
 }
-

--- a/templates/vpi_uhdm.h
+++ b/templates/vpi_uhdm.h
@@ -57,7 +57,7 @@ class uhdm_handleFactory {
 };
 
 /** Obtain a vpiHandle from a BaseClass (any) object */
-vpiHandle NewVpiHandle (UHDM::BaseClass* object);
+vpiHandle NewVpiHandle (const UHDM::BaseClass* object);
 
 s_vpi_value* String2VpiValue(const std::string& s);
 

--- a/templates/vpi_user.cpp
+++ b/templates/vpi_user.cpp
@@ -176,24 +176,6 @@ vpiHandle NewVpiHandle (const UHDM::BaseClass* object) {
   return reinterpret_cast<vpiHandle>(new uhdm_handle(object->UhdmType(), object));
 }
 
-/*
- * TODO: this way of new-ing handles is problematic as we generate new
- * objects that are never deleted, thus leaking memory.
- *
- * Goal should be to not have to allocate a shim-object but rather cast
- * our internal implementation pointer to vpiHandle.
- *
- * For most cases already, UHDM::BaseClass* would already fit the bill to
- * directly type-cast to vpiHandle which then is our opaque type we can cast
- * back to UHDM::BaseClass.
- *
- * Alas, we also use NewHandle() in a case where we don't have an object of
- * type BaseClass, thus we need the wrapper (see examples below in generated
- * code).
- *
- * So once we get that also onto some sort of super-base class (just a class
- * containing UhdmType() ?) we can fix this.
- */
 static vpiHandle NewHandle (UHDM_OBJECT_TYPE type, const void *object) {
   return reinterpret_cast<vpiHandle>(new uhdm_handle(type, object));
 }


### PR DESCRIPTION
In code generation, replace NewHandle() with NewVpiHandle()
where possible, to see the remaining parts to address.

No functional change otherwise.

Signed-off-by: Henner Zeller <h.zeller@acm.org>