### PR TITLE
Switch on optimization for SymbolFactory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,9 +63,19 @@ else()
   set(CMAKE_CXX_FLAGS_DEBUG
       "${CMAKE_CXX_FLAGS_DEBUG} ${TCMALLOC_COMPILE_OPTIONS} -Wall -O0 -g ${MY_CXX_WARNING_FLAGS}"
   )
+
+  # A lot of the generated files are so large that the compiler takes a long
+  # time to compile. Leave that at no optimization for now.
   set(CMAKE_CXX_FLAGS_RELEASE
       "${CMAKE_CXX_FLAGS_RELEASE} ${TCMALLOC_COMPILE_OPTIONS} -Wall -O0 -DNDEBUG ${MY_CXX_WARNING_FLAGS}"
   )
+
+  # Things relevant for performance and fast to compile with -O3
+  set_property(SOURCE
+    ${PROJECT_SOURCE_DIR}/src/SymbolFactory.cpp
+    PROPERTY COMPILE_FLAGS -O3
+ )
+
 endif()
 
 # model_gen generated


### PR DESCRIPTION
While we don't use optimization for the bulk of the generated files,
because they are slow to compile, SymbolFactory is quick to compile
with optimization and yields > 4x speedup for SymbolFactory
operations (on my laptop, Blackparrot2 compile spent
2.58s vs 11.8s in SymbolFactory::Make)).

So selectively switch on optimization for that file.

Signed-off-by: Henner Zeller <h.zeller@acm.org>