### PR TITLE
Reduce optimization levels of slow-to-compile files further.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ else()
     ${PROJECT_SOURCE_DIR}/src/clone_tree.cpp
     ${PROJECT_SOURCE_DIR}/src/Serializer_save.cpp
     ${PROJECT_SOURCE_DIR}/src/Serializer_restore.cpp
-    PROPERTY COMPILE_FLAGS -O1
+    PROPERTY COMPILE_FLAGS -O0
  )
 
 endif()


### PR DESCRIPTION
Since the optimization was done always, it also hurt the debug
build. Let's do no optimization on these files until we have figured
out how to make them compile fast.

Signed-off-by: Henner Zeller <h.zeller@acm.org>