### PR TITLE
Make sure the Tcl script does not stop if capnp emits a warning.

### DIFF
--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -1470,9 +1470,9 @@ proc generate_code { models } {
     set capnp_path [file dirname $capnp_path]
 
     if { $tcl_platform(platform) == "windows" } {
-        exec cmd /c "set PATH=$capnp_path;%PATH%; && cd /d [project_path]/src && $capnp_path/capnp.exe compile -oc++ UHDM.capnp"
+        exec -ignorestderr cmd /c "set PATH=$capnp_path;%PATH%; && cd /d [project_path]/src && $capnp_path/capnp.exe compile -oc++ UHDM.capnp"
     } else {
-        exec sh -c "export PATH=$capnp_path; $capnp_path/capnp compile -oc++:. [project_path]/src/UHDM.capnp"
+        exec -ignorestderr sh -c "export PATH=$capnp_path; $capnp_path/capnp compile -oc++:. [project_path]/src/UHDM.capnp"
     }
 
     # BaseClass.h


### PR DESCRIPTION
The default Tcl exec has the unfortunate feature to fail when
the command in question outputs on stderr, switch this off.

Signed-off-by: Henner Zeller <h.zeller@acm.org>