### PR TITLE
UHDM_OBJECT_TYPE: name enum directly, no typedef. Add indent.

### DIFF
--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -1204,7 +1204,7 @@ proc generate_code { models } {
         regsub -all {<UPPER_CLASSNAME>} $template [string toupper $classname] template
         foreach {id define} [defineType 1 uhdm${classname} ""] {}
         if {$define != ""} {
-            append defines "$define\n"
+            append defines "  $define\n"
         }
         printClassListener $classname
         printVpiListener $classname $classname $classname 0
@@ -1313,7 +1313,7 @@ proc generate_code { models } {
                     # define access properties (allModules...)
                     foreach {id define} [defineType 1 uhdm${name} ""] {}
                     if {$define != ""} {
-                        append defines "$define\n"
+                        append defines "  $define\n"
                     }
                     append methods($classname) [printMethods $classname $type $name $card $real_type]
                     printVpiListener $classname $vpi $type $card

--- a/templates/uhdm_types.h
+++ b/templates/uhdm_types.h
@@ -30,17 +30,17 @@
 #include "vpi_user.h"
 
 namespace UHDM {
-  class BaseClass;
-  typedef BaseClass any;
+class BaseClass;
+typedef BaseClass any;
 
-  typedef enum {
+enum UHDM_OBJECT_TYPE {
 <DEFINES>
-  } UHDM_OBJECT_TYPE;
-  
-  std::string UhdmName(UHDM_OBJECT_TYPE type);
+};
 
-  std::string VpiTypeName(vpiHandle h);
-  
+std::string UhdmName(UHDM_OBJECT_TYPE type);
+
+std::string VpiTypeName(vpiHandle h);
+
 };
 
 #endif


### PR DESCRIPTION
 * Change typedef enum {} foo C-ism to enum foo {}.
 * Fix generated indentation of the define enums.

Signed-off-by: Henner Zeller <h.zeller@acm.org>