### PR TITLE
Only write generated files if they actually changed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ add_custom_command(
           ${PROJECT_SOURCE_DIR}/model/models.lst ${CMAKE_CURRENT_BINARY_DIR}
   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
   DEPENDS ${PROJECT_SOURCE_DIR}/model_gen/model_gen.tcl
+          ${PROJECT_SOURCE_DIR}/model_gen/generate_elaborator.tcl
           ${PROJECT_SOURCE_DIR}/model_gen/parse_model.tcl
           ${PROJECT_SOURCE_DIR}/model/models.lst
           ${PROJECT_SOURCE_DIR}/templates/UHDM.capnp

--- a/model_gen/file_utils.tcl
+++ b/model_gen/file_utils.tcl
@@ -1,0 +1,63 @@
+# -*- mode: Tcl; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+#
+# Copyright 2019-2020 Alain Dargelas
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Set content of filename, but only if the file doesn't exist or the content
+# is different than before.
+# Return if content was overwritten.
+proc set_content_if_change { filename content } {
+    if {[file exists $filename]} {
+        set fid [open $filename]
+        set orig_content [read $fid]
+        close $fid
+        if {$orig_content == $content} {
+            return 0
+        }
+    }
+    set outfd [open $filename "w"]
+    puts -nonewline $outfd $content
+    close $outfd
+    return 1
+}
+
+# Copy file from source to destination if destination does not exist or
+# its content is different.
+proc file_copy_if_change { source dest } {
+    if {[file exists $dest]} {
+        set fid [open $source]
+        set source_content [read $fid]
+        close $fid
+
+        set fid [open $dest]
+        set dest_content [read $fid]
+        close $fid
+        if {$source_content == $dest_content} {
+            return 0
+        }
+    }
+    file copy -force -- $source $dest
+    return 1
+}
+
+proc find_file { baseDir filename } {
+    set filepath [ file join $baseDir $filename ]
+    if { [file exists $filepath] } { return $filepath; }
+
+    set dirs [ glob -nocomplain -type d [ file join $baseDir * ] ]
+    foreach dir $dirs {
+        set filepath [ find_file $dir $filename ]
+        if { [file exists $filepath] } { return $filepath; }
+    }
+}

--- a/model_gen/generate_elaborator.tcl
+++ b/model_gen/generate_elaborator.tcl
@@ -163,18 +163,13 @@ proc generate_elaborator { models } {
 
     regsub {<ELABORATOR_LISTENER>} $listener_content $vpi_listener listener_content
 
-    set listenerId [open "[project_path]/headers/ElaboratorListener.h" "w"]
-    puts $listenerId $listener_content
-    close $listenerId
-
+    set_content_if_change "[project_path]/headers/ElaboratorListener.h" $listener_content
 
     set fid [open "[project_path]/templates/clone_tree.h"]
     set clone_content [read $fid]
     close $fid
 
-    set cloneId [open "[project_path]/headers/clone_tree.h" "w"]
-    puts $cloneId $clone_content
-    close $cloneId
+    set_content_if_change "[project_path]/headers/clone_tree.h" $clone_content
 
     set fid [open "[project_path]/templates/clone_tree.cpp"]
     set clone_content [read $fid]
@@ -182,8 +177,5 @@ proc generate_elaborator { models } {
 
     regsub {<CLONE_CASES>} $clone_content $clone_cases clone_content
 
-    set cloneId [open "[project_path]/src/clone_tree.cpp" "w"]
-    puts $cloneId $clone_content
-    close $cloneId
-
+    set_content_if_change "[project_path]/src/clone_tree.cpp" $clone_content
 }

--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -52,20 +52,10 @@ proc project_path {} {
 file mkdir [project_path]/src
 file mkdir [project_path]/headers
 
+source [exec_path]/file_utils.tcl
 source [exec_path]/pdict.tcl
 source [exec_path]/parse_model.tcl
 source [exec_path]/generate_elaborator.tcl
-
-proc find_file { baseDir filename } {
-    set filepath [ file join $baseDir $filename ]
-    if { [file exists $filepath] } { return $filepath; }
-
-    set dirs [ glob -nocomplain -type d [ file join $baseDir * ] ]
-    foreach dir $dirs {
-        set filepath [ find_file $dir $filename ]
-        if { [file exists $filepath] } { return $filepath; }
-    }
-}
 
 proc parse_vpi_user_defines { } {
     global ID
@@ -652,7 +642,6 @@ proc generate_group_checker { model } {
         regsub -all {<GROUPNAME>} $template $groupname template
         regsub -all {<UPPER_GROUPNAME>} $template [string toupper $groupname] template
 
-        set oid [open "$output" "w"]
         set checktype ""
         dict for {key val} $data {
             if {($key == "obj_ref") || ($key == "class_ref")} {
@@ -679,8 +668,7 @@ proc generate_group_checker { model } {
             }
         }
         regsub -all {<CHECKTYPE>} $template $checktype template
-        puts $oid $template
-        close $oid
+        set_content_if_change $output $template
     }
 }
 
@@ -700,9 +688,8 @@ proc write_vpi_listener_cpp {} {
     }
     regsub {<VPI_LISTENERS>} $listener_cpp $vpi_listener listener_cpp
     regsub {<VPI_ANY_LISTENERS>} $listener_cpp $vpi_any_listener listener_cpp
-    set listenerId [open "[project_path]/src/vpi_listener.cpp" "w"]
-    puts $listenerId $listener_cpp
-    close $listenerId
+
+    set_content_if_change "[project_path]/src/vpi_listener.cpp" $listener_cpp
 }
 
 proc write_vpi_listener_h {} {
@@ -716,9 +703,8 @@ proc write_vpi_listener_h {} {
         append vpi_listener $VPI_LISTENERS_HEADER($classname)
     }
     regsub {<VPI_LISTENERS_HEADER>} $listener_h $vpi_listener listener_h
-    set listenerId [open "[project_path]/headers/vpi_listener.h" "w"]
-    puts $listenerId $listener_h
-    close $listenerId
+
+    set_content_if_change "[project_path]/headers/vpi_listener.h" $listener_h
 }
 
 proc write_uhdm_forward_decl {} {
@@ -732,9 +718,8 @@ proc write_uhdm_forward_decl {} {
         append forward_declaration "class $classname;\n"
     }
     regsub {<UHDM_FORWARD_DECL>} $uhdm_forward_h $forward_declaration uhdm_forward_h
-    set forwardId [open "[project_path]/headers/uhdm_forward_decl.h" "w"]
-    puts $forwardId $uhdm_forward_h
-    close $forwardId
+
+    set_content_if_change "[project_path]/headers/uhdm_forward_decl.h" $uhdm_forward_h
 }
 
 proc write_VpiListener_h {} {
@@ -748,9 +733,7 @@ proc write_VpiListener_h {} {
         append vpi_listener $CLASS_LISTENER($classname)
     }
     regsub {<VPI_LISTENER_METHODS>} $listener_content $vpi_listener listener_content
-    set listenerId [open "[project_path]/headers/VpiListener.h" "w"]
-    puts $listenerId $listener_content
-    close $listenerId
+    set_content_if_change "[project_path]/headers/VpiListener.h" $listener_content
 }
 
 set SHORT_VISITOR_LIST { class_obj
@@ -934,9 +917,7 @@ $relations
 "
     }
     regsub {<OBJECT_VISITORS>} $visitor_cpp $vpi_visitor visitor_cpp
-    set visitorId [open "[project_path]/src/vpi_visitor.cpp" "w"]
-    puts $visitorId $visitor_cpp
-    close $visitorId
+    set_content_if_change "[project_path]/src/vpi_visitor.cpp" $visitor_cpp
 }
 
 proc write_capnp { capnp_schema_all capnp_root_schema } {
@@ -945,9 +926,8 @@ proc write_capnp { capnp_schema_all capnp_root_schema } {
     close $fid
     regsub {<CAPNP_SCHEMA>} $capnp_content $capnp_schema_all capnp_content
     regsub {<CAPNP_ROOT_SCHEMA>} $capnp_content $capnp_root_schema capnp_content
-    set capnpId [open "[project_path]/src/UHDM.capnp" "w"]
-    puts $capnpId $capnp_content
-    close $capnpId
+
+    return [set_content_if_change "[project_path]/src/UHDM.capnp" $capnp_content]
 }
 
 proc write_uhdm_h { headers} {
@@ -956,7 +936,6 @@ proc write_uhdm_h { headers} {
     set fid [open "[project_path]/templates/uhdm.h"]
     set uhdm_content [read $fid]
     close $fid
-    set uhdmId [open "[project_path]/headers/uhdm.h" "w"]
 
     set name_id_map "\nstd::string UHDM::UhdmName(UHDM_OBJECT_TYPE type) \{
       switch (type) \{
@@ -973,29 +952,23 @@ proc write_uhdm_h { headers} {
     append uhdm_name_map $name_id_map
 
     regsub -all {<INCLUDE_FILES>} $uhdm_content $headers uhdm_content
-    puts $uhdmId $uhdm_content
-    close $uhdmId
-
+    set_content_if_change "[project_path]/headers/uhdm.h" $uhdm_content
 }
 
 proc write_uhdm_types_h { defines } {
     set fid [open "[project_path]/templates/uhdm_types.h"]
     set uhdm_content [read $fid]
     close $fid
-    set uhdmId [open "[project_path]/headers/uhdm_types.h" "w"]
     regsub -all {<DEFINES>} $uhdm_content $defines uhdm_content
-    puts $uhdmId $uhdm_content
-    close $uhdmId
+    set_content_if_change "[project_path]/headers/uhdm_types.h" $uhdm_content
 }
 
 proc write_containers_h { containers } {
     set fid [open "[project_path]/templates/containers.h"]
     set container_content [read $fid]
     close $fid
-    set containerId [open "[project_path]/headers/containers.h" "w"]
     regsub -all {<CONTAINERS>} $container_content $containers container_content
-    puts $containerId $container_content
-    close $containerId
+    set_content_if_change "[project_path]/headers/containers.h" $container_content
 }
 
 proc update_vpi_inst { baseclass classname lvl } {
@@ -1199,7 +1172,6 @@ proc generate_code { models } {
         }
         lappend classes $classname
 
-        set oid [open "[project_path]/headers/$classname.h" "w"]
         regsub -all {<CLASSNAME>} $template $classname template
         regsub -all {<UPPER_CLASSNAME>} $template [string toupper $classname] template
         foreach {id define} [defineType 1 uhdm${classname} ""] {}
@@ -1397,8 +1369,7 @@ proc generate_code { models } {
         regsub -all {<MEMBERS>} $template $members($classname) template
         regsub -all {<EXTENDS>} $template BaseClass template
 
-        puts $oid $template
-        close $oid
+        set_content_if_change "[project_path]/headers/$classname.h" $template
 
         # VPI
         update_vpi_inst $classname $classname 1
@@ -1457,32 +1428,31 @@ proc generate_code { models } {
     regsub -all {<VPI_GET_DELAY_BODY>} $vpi_user $vpi_get_delay_body vpi_user
     regsub {<VPI_GET_STR_BODY>} $vpi_user $vpi_get_str_body vpi_user
 
-    set vpi_userId [open "[project_path]/src/vpi_user.cpp" "w"]
-    puts $vpi_userId $vpi_user
-    close $vpi_userId
+    set_content_if_change "[project_path]/src/vpi_user.cpp" $vpi_user
 
     # UHDM.capnp
-    write_capnp $capnp_schema_all $capnp_root_schema
-    log "Generating Capnp schema..."
-    file delete -force [project_path]/src/UHDM.capnp.*
-    set capnp_path [find_file $working_dir "capnpc-c++$exeext"]
-    puts "capnp_path = $capnp_path"
-    set capnp_path [file dirname $capnp_path]
+    if {[write_capnp $capnp_schema_all $capnp_root_schema]} {
+        log "Generating Capnp schema..."
+        file delete -force [project_path]/src/UHDM.capnp.*
+        set capnp_path [find_file $working_dir "capnpc-c++$exeext"]
+        puts "capnp_path = $capnp_path"
+        set capnp_path [file dirname $capnp_path]
 
-    if { $tcl_platform(platform) == "windows" } {
-        exec -ignorestderr cmd /c "set PATH=$capnp_path;%PATH%; && cd /d [project_path]/src && $capnp_path/capnp.exe compile -oc++ UHDM.capnp"
-    } else {
-        exec -ignorestderr sh -c "export PATH=$capnp_path; $capnp_path/capnp compile -oc++:. [project_path]/src/UHDM.capnp"
+        if { $tcl_platform(platform) == "windows" } {
+            exec -ignorestderr cmd /c "set PATH=$capnp_path;%PATH%; && cd /d [project_path]/src && $capnp_path/capnp.exe compile -oc++ UHDM.capnp"
+        } else {
+            exec -ignorestderr sh -c "export PATH=$capnp_path; $capnp_path/capnp compile -oc++:. [project_path]/src/UHDM.capnp"
+        }
     }
 
     # BaseClass.h
-    file copy -force -- "[project_path]/templates/BaseClass.h" "[project_path]/headers/BaseClass.h"
+    file_copy_if_change "[project_path]/templates/BaseClass.h" "[project_path]/headers/BaseClass.h"
 
     # SymbolFactory.h
-    file copy -force -- "[project_path]/templates/SymbolFactory.h" "[project_path]/headers/SymbolFactory.h"
+    file_copy_if_change "[project_path]/templates/SymbolFactory.h" "[project_path]/headers/SymbolFactory.h"
 
     # SymbolFactory.cpp
-    file copy -force -- "[project_path]/templates/SymbolFactory.cpp" "[project_path]/src/SymbolFactory.cpp"
+    file_copy_if_change "[project_path]/templates/SymbolFactory.cpp" "[project_path]/src/SymbolFactory.cpp"
 
     # Serializer.cpp
     set files "Serializer_save.cpp Serializer_restore.cpp vpi_uhdm.h Serializer.h"
@@ -1558,16 +1528,14 @@ $RESTORE($class)
         regsub {<CAPNP_INIT_FACTORIES>} $serializer_content $capnp_init_factories serializer_content
         regsub {<CAPNP_RESTORE_FACTORIES>} $serializer_content $capnp_restore_factories serializer_content
         if {$file == "vpi_uhdm.h" || $file == "Serializer.h"} {
-            set serializerId [open "[project_path]/headers/$file" "w"]
+            set_content_if_change "[project_path]/headers/$file" $serializer_content
         } else {
-            set serializerId [open "[project_path]/src/$file" "w"]
+            set_content_if_change "[project_path]/src/$file" $serializer_content
         }
-        puts $serializerId $serializer_content
-        close $serializerId
     }
 
     # vpi_visitor.h
-    file copy -force -- "[project_path]/templates/vpi_visitor.h" "[project_path]/headers/vpi_visitor.h"
+    file_copy_if_change "[project_path]/templates/vpi_visitor.h" "[project_path]/headers/vpi_visitor.h"
 
     # vpi_visitor.cpp
     write_vpi_visitor_cpp


### PR DESCRIPTION
This reduces churn of what the compiler has to re-compile a lot
when doing small changes to code generation and object models:
only files that don't exist or whose output actually change
are be overwritten.

Tested:
  touch model/*.yaml ; make
The tcl script is run, but it does not generate any changed artifacts,
so no files are recompiled.

Signed-off-by: Henner Zeller <h.zeller@acm.org>