### PR TITLE
Implement clone_tree() using overloaded BaseClass::DeepClone() (and fixing a bug ?)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,6 @@ else()
   # TODO: Reduce complexity/branches etc. whatever makes the optimizer freak
   # out. The code-generation is pretty linear right now.
   set_property(SOURCE
-    ${PROJECT_SOURCE_DIR}/src/clone_tree.cpp
     ${PROJECT_SOURCE_DIR}/src/Serializer_save.cpp
     ${PROJECT_SOURCE_DIR}/src/Serializer_restore.cpp
     PROPERTY COMPILE_FLAGS -O0

--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -1186,7 +1186,12 @@ proc generate_code { models } {
         }
         printClassListener $classname
         printVpiListener $classname $classname $classname 0
-        if {$modeltype != "class_def"} {
+
+
+        if {$modeltype == "class_def"} {
+            # DeepClone() not implemented for class_def; just declare to narrow the covariant return type.
+            append methods($classname) "\n    ${classname}* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener) const override = 0;\n"
+        } else {
             # Builtin properties do not need to be specified in each models
             # Builtins: "vpiParent, Parent type, vpiFile, vpiLineNo, Id" method and field
             append methods($classname) [printMethods $classname BaseClass vpiParent 1]
@@ -1201,6 +1206,7 @@ proc generate_code { models } {
             lappend vpi_get_body_inst($classname) [list $classname int vpiLineNo 1]
             append methods($classname) [printMethods $classname "unsigned int" uhdmId 1]
             append members($classname) [printMembers "unsigned int" uhdmId 1]
+            append methods($classname) "\n    ${classname}* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener) const override;\n"
             append vpi_handle_body($classname) [printGetHandleBody $classname BaseClass vpiParent vpiParent 1]
             lappend capnp_schema($classname) [list vpiParent UInt64]
             lappend capnp_schema($classname) [list uhdmParentType UInt64]

--- a/templates/BaseClass.h
+++ b/templates/BaseClass.h
@@ -31,20 +31,21 @@
 
 namespace UHDM {
   class Serializer;
+  class ElaboratorListener;
   static std::string nonamebaseclass ("");
 
   class ClientData {
   public:
     virtual ~ClientData(){};
   };
-  
+
   class BaseClass {
     friend Serializer;
 
   public:
     // Use implicit constructor to initialize all members
     // BaseClass()
-    
+
     virtual ~BaseClass(){}
 
     Serializer* GetSerializer() { return serializer_; }
@@ -81,17 +82,18 @@ namespace UHDM {
 
     virtual bool UhdmId(unsigned int id) = 0;
 
+    // Create a deep copy of this object.
+    virtual BaseClass* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener) const = 0;
+
   protected:
     void SetSerializer(Serializer* serial) { serializer_ = serial; }
-    
+
     Serializer* serializer_;
 
     ClientData* clientData_;
 
   };
-  
-};
 
-
+}  // namespace UHDM
 
 #endif

--- a/templates/clone_tree.cpp
+++ b/templates/clone_tree.cpp
@@ -32,15 +32,8 @@ using namespace UHDM;
 namespace UHDM {
 
 BaseClass* clone_tree (const BaseClass* root, Serializer& s, ElaboratorListener* elaborator) {
-  if (root == nullptr)
-    return nullptr;
-  BaseClass* clone = nullptr;
-  switch (root->VpiType()) {  
-<CLONE_CASES>
-  default:
-    break;
-  }
-  return clone;
+  return root ? root->DeepClone(&s, elaborator) : nullptr;
 }
+<CLONE_IMPLEMENTATIONS>
 
-};
+}  // UHDM namespace


### PR DESCRIPTION
 * The original implementation used a gigantic switch/case
   statement with lots of C-style casts.
   C++ offers an opportunity to do that type-safe and more readably.
 * Impelement a BaseClass::DeepClone() method instead, essentially
   with the same implementation, but for each class separately.
 * Using covariant return types, this is now also type-safe and
   avoids most of the casts (except the dynamic casts).
 * Compilation time for clone_tree.cpp went down from many minutes
   in -O3 to < 30 seconds.
   So it could be removed from the optimization excempt list in
   cmake.
 * I expect clone_tree() to go away in favor of directly calling
   DeepClone(), but left it in for now for backward compatibility.
   (... with a one-line implementation).


As an example how it looks, here is a snippet from the previous switch/case statement in `clone_tree()` with lots of forced C-style casts:

```c++
 // ... somewhere in middle of switch/case
  case vpiTchkTerm: {
    tchk_term* clone_obj = s.MakeTchk_term();
    unsigned long id = clone_obj->UhdmId();
    *clone_obj =  *((tchk_term*)root);
    clone_obj->UhdmId(id);
    clone = clone_obj;
    clone_obj->Expr((expr*) clone_tree(((tchk_term*)root)->Expr(), s, elaborator));
    clone_obj->Condition((expr*) clone_tree(((tchk_term*)root)->Condition(), s, elaborator));
    break;
  }
  case vpiNetBit: {
    net_bit* clone_obj = dynamic_cast<net_bit*>(elaborator->bindNet(((net_bit*)root)->VpiName()));
    if (clone_obj == nullptr) {
      clone_obj = s.MakeNet_bit();
    }
    unsigned long id = clone_obj->UhdmId();
    *clone_obj =  *((net_bit*)root);
    clone_obj->UhdmId(id);
    clone = clone_obj;
    if (auto vec = ((net_bit*)root)->Exprs()) {
      auto clone_vec = s.MakeExprVec();
      clone_obj->Exprs(clone_vec);
      for (auto obj : *vec) {
        clone_vec->push_back((expr*) clone_tree(obj, s, elaborator));
      }
    }
    if (auto vec = ((nets*)root)->Ports()) { // ...
   // ... and so on
```

In the new implementation, each of these parts is now created as an implementation of
```
virtual BaseClass* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener) const;
```
... of which the overriding methods use a narrower covariant return type; so `tchk_term::DeepClone()` actually returns a `tchk_term*`

The equivalent snippet from above is now looking like this:
```c++
tchk_term* tchk_term::DeepClone(Serializer* serializer, ElaboratorListener* elaborator) const {
  tchk_term* const clone = serializer->MakeTchk_term();
  const unsigned long id = clone->UhdmId();
  *clone = *this;
  clone->UhdmId(id);
  if (auto obj = Expr()) clone->Expr(obj->DeepClone(serializer, elaborator));
  if (auto obj = Condition()) clone->Condition(obj->DeepClone(serializer, elaborator));

  return clone;
}

net_bit* net_bit::DeepClone(Serializer* serializer, ElaboratorListener* elaborator) const {
  net_bit* clone = dynamic_cast<net_bit*>(elaborator->bindNet(VpiName()));
  if (clone == nullptr) {
    clone = serializer->MakeNet_bit();
  }
  const unsigned long id = clone->UhdmId();
  *clone = *this;
  clone->UhdmId(id);
  if (auto vec = Exprs()) {
    auto clone_vec = serializer->MakeExprVec();
    clone->Exprs(clone_vec);
    for (auto obj : *vec) {
      clone_vec->push_back(obj->DeepClone(serializer, elaborator));
    }
  }
  if (auto vec = Ports()) { // ...
```

Not only is this now using the C++ features, it is also clear that we don't have to use C-style casts anymore, as we actually get the correct type back. Thus we can also be more sure that things are correct.

**CAVE: difference in Surelog tests; a fixed bug ?**

Running this with Surelog shows actually four differences. I have not drilled down entirely yet why the difference is there, but I believe it actually is _fixing_ a bug from the previous version.

Difference in logs are for
  
  * `tests/JKFlipflop/JKFlipflop.log`
  * `tests/StructVar/StructVar.log`
  * `tests/WildConn/WildConn.log`
  * `tests/FSMBsp13/FSMBsp13.log`

In all these cases, a `vpiInstance` appears in the UHDM dump where it wasn't before.

So the JKFlipFlop test has the following diff for instance

![jkflop diff](https://user-images.githubusercontent.com/140937/86506376-b8fa5380-bd83-11ea-8120-bd337231dbbf.png)

Maybe there was a bad type-cast in the version before which made this not show up before ? If this looks correct, then we're ready to merge.

If this is unexpected, so a `vpiInstance` should _not_ be there, then don't merge - and I'd be happy about suggestions how to further drill this down because I think this new implementation is the way to go and we should fix if there are any bugs.
