### PR TITLE
Add non-standard tag for struct member reference

### DIFF
--- a/model/ref_obj.yaml
+++ b/model/ref_obj.yaml
@@ -55,4 +55,10 @@
     name: task func
     vpi: vpiTaskFunc
     type: task_func
-    card: 1  
+    card: 1
+ # Non Standard: identify reference to a struct member {base : {10'h0, ...  }}
+  - property: is_struct_member
+    name: is struct member
+    vpi: vpiStructMember
+    type: bool
+    card: 1    

--- a/templates/uhdm.h
+++ b/templates/uhdm.h
@@ -44,6 +44,7 @@
 
 #define vpiWaits     3009
 #define vpiDisables  3010
+#define vpiStructMember 3011
 
 #define vpiUnsupportedStmt 4000
 #define vpiUnsupportedExpr 4001


### PR DESCRIPTION
Non standard extension like these are made to be able to keep an abstract representation of the design without the need to bit blast all data members and leave it to the client application to decide if bit blasting is required.