### PR TITLE
Regenerate UHDM.capnp.h if it got lost.

### DIFF
--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -1445,7 +1445,8 @@ proc generate_code { models } {
     set_content_if_change "[project_path]/src/vpi_user.cpp" $vpi_user
 
     # UHDM.capnp
-    if {[write_capnp $capnp_schema_all $capnp_root_schema]} {
+    if {[write_capnp $capnp_schema_all $capnp_root_schema]
+        || ![file exists "[project_path]/src/UHDM.capnp.h"]} {
         log "Generating Capnp schema..."
         file delete -force [project_path]/src/UHDM.capnp.*
         set capnp_path [find_file $working_dir "capnpc-c++$exeext"]


### PR DESCRIPTION
Even if the schema didn't change, the UHDM.capnp.h file might
have been not there for other reasons. In that case, run capnp.

Signed-off-by: Henner Zeller <h.zeller@acm.org>