### PR TITLE
Add missing generated src from CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,42 +108,43 @@ add_custom_command(
           ${templates_SRC})
 
 set(uhdm_SRC
-    ${PROJECT_SOURCE_DIR}/src/vpi_listener.cpp
-    ${PROJECT_SOURCE_DIR}/src/vpi_visitor.cpp
-    ${PROJECT_SOURCE_DIR}/src/vpi_user.cpp
-    ${PROJECT_SOURCE_DIR}/src/SymbolFactory.cpp
-    ${PROJECT_SOURCE_DIR}/src/Serializer_save.cpp
     ${PROJECT_SOURCE_DIR}/src/Serializer_restore.cpp
+    ${PROJECT_SOURCE_DIR}/src/Serializer_save.cpp
+    ${PROJECT_SOURCE_DIR}/src/SymbolFactory.cpp
     ${PROJECT_SOURCE_DIR}/src/UHDM.capnp.c++
-    ${PROJECT_SOURCE_DIR}/src/clone_tree.cpp
     ${PROJECT_SOURCE_DIR}/src/actual_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/instance_item.cpp
+    ${PROJECT_SOURCE_DIR}/src/clone_tree.cpp
     ${PROJECT_SOURCE_DIR}/src/enum_struct_packed_net_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/ref_obj_interf_net_var_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/enum_struct_union_packed_var_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/expr_ref_obj_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/variable_drivers_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/variable_loads_group.cpp
     ${PROJECT_SOURCE_DIR}/src/enum_struct_union_packed_array_typespec_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/operand_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/stmt.cpp
-    ${PROJECT_SOURCE_DIR}/src/expr_sequence_inst_named_event_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/enum_struct_union_packed_var_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/expr_constr_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/expr_dist.cpp
+    ${PROJECT_SOURCE_DIR}/src/expr_interf_expr_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/expr_ref_obj_group.cpp
     ${PROJECT_SOURCE_DIR}/src/expr_sequence_inst_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/expr_sequence_inst_named_event_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/expr_tchk_term_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/expr_typespec_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/instance_item.cpp
+    ${PROJECT_SOURCE_DIR}/src/interf_prog_mod_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/operand_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/parameters.cpp
+    ${PROJECT_SOURCE_DIR}/src/pattern_expr_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/property_expr_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/property_expr_named_event_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/property_inst_spec_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/ref_obj_interf_net_var_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/simple_expr_use_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/stmt.cpp
     ${PROJECT_SOURCE_DIR}/src/task_func_named_begin_fork_group.cpp
     ${PROJECT_SOURCE_DIR}/src/tf_call_args.cpp
-    ${PROJECT_SOURCE_DIR}/src/expr_interf_expr_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/expr_tchk_term_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/simple_expr_use_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/expr_dist.cpp
-    ${PROJECT_SOURCE_DIR}/src/expr_typespec_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/property_inst_spec_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/property_expr_named_event_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/property_expr_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/pattern_expr_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/expr_constr_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/parameters.cpp
-    ${PROJECT_SOURCE_DIR}/src/interf_prog_mod_group.cpp
-    ${PROJECT_SOURCE_DIR}/src/variables_operation_group.cpp)
+    ${PROJECT_SOURCE_DIR}/src/variable_drivers_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/variable_loads_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/variables_operation_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/vpi_listener.cpp
+    ${PROJECT_SOURCE_DIR}/src/vpi_user.cpp
+    ${PROJECT_SOURCE_DIR}/src/vpi_visitor.cpp
+)
 
 foreach(src_file ${uhdm_SRC})
   set_source_files_properties(${src_file} PROPERTIES GENERATED TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ set(uhdm_SRC
     ${PROJECT_SOURCE_DIR}/src/expr_typespec_group.cpp
     ${PROJECT_SOURCE_DIR}/src/instance_item.cpp
     ${PROJECT_SOURCE_DIR}/src/interf_prog_mod_group.cpp
+    ${PROJECT_SOURCE_DIR}/src/method_func_task_call_group.cpp
     ${PROJECT_SOURCE_DIR}/src/operand_group.cpp
     ${PROJECT_SOURCE_DIR}/src/parameters.cpp
     ${PROJECT_SOURCE_DIR}/src/pattern_expr_group.cpp
@@ -136,6 +137,7 @@ set(uhdm_SRC
     ${PROJECT_SOURCE_DIR}/src/ref_obj_interf_net_var_group.cpp
     ${PROJECT_SOURCE_DIR}/src/simple_expr_use_group.cpp
     ${PROJECT_SOURCE_DIR}/src/stmt.cpp
+    ${PROJECT_SOURCE_DIR}/src/sys_func_task_call_group.cpp
     ${PROJECT_SOURCE_DIR}/src/task_func_named_begin_fork_group.cpp
     ${PROJECT_SOURCE_DIR}/src/tf_call_args.cpp
     ${PROJECT_SOURCE_DIR}/src/variable_drivers_group.cpp


### PR DESCRIPTION
Also, sort all the generated sources, so that it is easier to pinpoint missing ones.