### PR TITLE
Add nodes for import statements

### DIFF
--- a/model/import.yaml
+++ b/model/import.yaml
@@ -15,15 +15,15 @@
 # Universal Hardware Data Model (UHDM) "import_stmt" formal description
 
 - obj_def: import
-  - extends: atomic_stmt
+  - extends: typespec
   - property: type
     name: uhdmimport
     vpi: vpiType
     type: unsigned int
     card: 1
-  - obj_ref: items
-    name: items
+  - obj_ref: item
+    name: item
     vpi: vpiImport
     type: constant
-    card: any
+    card: 1
 

--- a/model/import.yaml
+++ b/model/import.yaml
@@ -1,0 +1,29 @@
+# Copyright 2019-2020 Alain Dargelas
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Universal Hardware Data Model (UHDM) "import_stmt" formal description
+
+- obj_def: import
+  - extends: atomic_stmt
+  - property: type
+    name: uhdmimport
+    vpi: vpiType
+    type: unsigned int
+    card: 1
+  - obj_ref: items
+    name: items
+    vpi: vpiImport
+    type: constant
+    card: any
+

--- a/model/models.lst
+++ b/model/models.lst
@@ -236,4 +236,5 @@ method_task_call.yaml
 func_call.yaml
 task_call.yaml
 constraint.yaml
+import.yaml
 uhdm.yaml

--- a/templates/vpi_visitor.cpp
+++ b/templates/vpi_visitor.cpp
@@ -57,6 +57,7 @@ typedef std::set<vpiHandle> VisitedContainer;
 #define vpiSequenceExpr 3005
 #define vpiUnsupportedStmt 4000
 #define vpiUnsupportedExpr 4001
+#define uhdmimport 2577
 
 #else
 


### PR DESCRIPTION
This pull request introduces a UHDM-specific node type to keep track of imported symbols. This is needed for some tools (like Verilator) to resolve unqualified identifiers.