### PR TITLE
Built and run successfully on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,13 @@ add_library(uhdm STATIC ${uhdm_SRC})
 set_target_properties(uhdm PROPERTIES PUBLIC_HEADER "${UHDM_PUBLIC_HEADERS}")
 target_link_libraries(uhdm PUBLIC capnp)
 
-if (UNIX)
+if(APPLE)
+  target_link_libraries(uhdm
+      PUBLIC dl
+      PUBLIC util
+      PUBLIC m
+      PUBLIC pthread)
+else(UNIX)
   target_link_libraries(uhdm
       PUBLIC dl
       PUBLIC util


### PR DESCRIPTION
macOS does not have library "rt" and does not need it. Removing "PUBLIC rt" for Apple in CMakeLists.txt makes UHDM built successfully on macOS and pass 100% unit tests.