### PR TITLE
Stability updates for Windows CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,19 +30,17 @@ matrix:
 
     - os: windows
       language: shell
-      before_install:
-        - curl -L http://gnuwin32.sourceforge.net/downlinks/make-bin-zip.php > $TEMP/make-3.81-bin.zip
-        - 7z x -y -o"/c/make" $TEMP/make-3.81-bin.zip
-        - curl -L http://gnuwin32.sourceforge.net/downlinks/make-dep-zip.php > $TEMP/make-dep.zip
-        - 7z x -y -o"/c/make" $TEMP/make-dep.zip
-        - curl -L https://bitbucket.org/tombert/tcltk/downloads/tcltk87-8.7a3.3.tcl87.Win10.x86_64.tgz > $TEMP/tcltk87-8.7a3.3.tcl87.Win10.x86_64.tgz
-        - pushd $TEMP && 7z e -y $TEMP/tcltk87-8.7a3.3.tcl87.Win10.x86_64.tgz && popd
-        - pushd $TEMP && 7z x -y $TEMP/tcltk87-8.7a3.3.tcl87.Win10.x86_64.tar && popd
-        - mv "$TEMP/tcltk87-8.7a3.3.tcl87.Win10.x86_64" "/c/tcltk87"
+      install:
+        - choco install -y make
+        - choco install -y visualstudio2019buildtools --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+        - choco install -y visualstudio2019-workload-vctools
 
       env:
-        - PATH=/c/make/bin:/c/tcltk87/bin:$PATH
         - PREFIX=$TRAVIS_BUILD_DIR/install
+        - CMAKE_GENERATOR="Visual Studio 16 2019"
+        - CMAKE_GENERATOR_PLATFORM=x64
+        - PATH=/c/make/bin:$PATH
+        - PATH="/c/Program Files/Git/mingw64/bin:$PATH"
 
 # Build steps
 script:


### PR DESCRIPTION
Stability updates for Windows CI build
* Use choco to install packages instead of hardcoding remote paths
  (tclsh remote location disappeared and builds started failing)
* Build for x64 platform to be consistent with linux build
* Don't need to install tclsh. Mingw carries a version of tclsh.
* Surelog requires minimum VS2019. Build UHDM also with the same
  version to be consistent.