### PR TITLE
Support for CI Builds on GHA

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,142 @@
+name: 'main'
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  linux-gcc:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -qq
+        sudo apt install -y g++-9 build-essential cmake tclsh
+
+    - name: Git pull
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Configure shell
+      run: |
+        echo 'CC=gcc-9' >> $GITHUB_ENV
+        echo 'CXX=g++-9' >> $GITHUB_ENV
+        echo 'PREFIX=/usr/include' >> $GITHUB_ENV
+
+    - name: Show shell configuration
+      run: |
+        env
+        which cmake && cmake --version
+        which make && make --version
+        which tclsh && echo 'puts [info patchlevel];exit 0' | tclsh
+        which $CC && $CC --version
+        which $CXX && $CXX --version
+
+    - name: Build & Test
+      run: |
+        make release
+        make test
+        sudo make install
+        make test_install
+
+  msys2-gcc:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+    - name: Setup Msys2
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MSYS
+        update: true
+        install: make cmake ninja gcc
+      env:
+        MSYS2_PATH_TYPE: inherit
+
+    - name: Configure Git
+      run: git config --global core.autocrlf input
+      shell: bash
+
+    - name: Git pull
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Configure shell
+      run: |
+        echo 'CC=gcc' >> $GITHUB_ENV
+        echo 'CXX=g++' >> $GITHUB_ENV
+        echo 'PREFIX=$PWD/install' >> $GITHUB_ENV
+        echo 'CMAKE_GENERATOR=Ninja' >> $GITHUB_ENV
+        echo 'NO_TCMALLOC=On' >> $GITHUB_ENV
+
+    - name: Show shell configuration
+      run: |
+        env
+        where cmake && cmake --version
+        where make && make --version
+        where ninja && ninja --version
+        where tclsh && echo 'puts [info patchlevel];exit 0' | tclsh
+        where $CC && $CC --version
+        where $CXX && $CXX --version
+
+    - name: Build & Test
+      run: |
+        make release
+        make test
+        make install
+        make test_install
+
+  windows-msvc:
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: cmd
+
+    steps:
+    - name: Install Core Dependencies
+      run: |
+        choco install -y make
+
+    - run: git config --global core.autocrlf input
+      shell: bash
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Build & Test
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+
+        set CC=cl
+        set CXX=cl
+        set PREFIX=%GITHUB_WORKSPACE%\install
+        set CMAKE_GENERATOR=Ninja
+        set NO_TCMALLOC=On
+        set CPU_CORES=%NUMBER_OF_PROCESSORS%
+
+        set MAKE_DIR=C:\make\bin
+        set TCL_DIR=%PROGRAMFILES%\Git\mingw64\bin
+        set PATH=%MAKE_DIR%;%TCL_DIR%;%PATH%
+
+        set
+        where cmake && cmake --version
+        where make && make --version
+        where ninja && ninja --version
+
+        make release
+        make test
+        make install
+        make test_install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
         make test_install
 
   msys2-gcc:
+    if: false # disable for the time being until we figure out the reason for slow builds and intermittent link issues
     runs-on: windows-latest
     defaults:
       run:

--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,10 @@
 # Project specific folders and files
 /headers
 /src
-/CMakeBuilds
-/.vs
 
 # Build directory
+.vs/
+.vscode/
 build/
+out/
+CMakeBuilds/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,12 +60,17 @@ if(MSVC)
   )
   set(CMAKE_EXE_LINKER_FLAGS /STACK:8388608)  # 8MB stack size
 else()
+  if(DEFINED ENV{MSYSTEM})
+    # Under MSYS some files are too large to build without additional flags
+    set(MSYS_COMPILE_OPTIONS "-m64 -Wa,-mbig-obj")
+  endif()
+
   set(CMAKE_CXX_FLAGS_DEBUG
-      "${CMAKE_CXX_FLAGS_DEBUG} ${TCMALLOC_COMPILE_OPTIONS} -Wall -O0 -g ${MY_CXX_WARNING_FLAGS}"
+      "${CMAKE_CXX_FLAGS_DEBUG} ${TCMALLOC_COMPILE_OPTIONS} -Wall -O0 -g ${MSYS_COMPILE_OPTIONS} ${MY_CXX_WARNING_FLAGS}"
   )
 
   set(CMAKE_CXX_FLAGS_RELEASE
-      "${CMAKE_CXX_FLAGS_RELEASE} ${TCMALLOC_COMPILE_OPTIONS} -Wall -O3 -DNDEBUG ${MY_CXX_WARNING_FLAGS}"
+      "${CMAKE_CXX_FLAGS_RELEASE} ${TCMALLOC_COMPILE_OPTIONS} -Wall -O3 -DNDEBUG ${MSYS_COMPILE_OPTIONS} ${MY_CXX_WARNING_FLAGS}"
   )
 
   # Some of these files make the optimizer take so long, that we excempt some
@@ -164,6 +169,9 @@ set(UHDM_PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/headers/uhdm.h)
 
 add_library(uhdm STATIC ${uhdm_SRC})
 set_target_properties(uhdm PROPERTIES PUBLIC_HEADER "${UHDM_PUBLIC_HEADERS}")
+target_compile_definitions(uhdm
+  PUBLIC PLI_DLLISPEC=
+  PUBLIC PLI_DLLESPEC=)
 target_link_libraries(uhdm PUBLIC capnp)
 
 if(APPLE)

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,27 @@
 # UHDM top Makefile (Wrapper to cmake)
+
+# Use bash as the default shell
+SHELL := /bin/bash
+
+ifeq ($(CPU_CORES),)
+	CPU_CORES := $(shell nproc)
+	ifeq ($(CPU_CORES),)
+		CPU_CORES := 1
+	endif
+endif
+
 PREFIX?=/usr/local
 
 release: build
-	cmake --build build --config Release
+	cmake --build build -j $(CPU_CORES)
 
 debug:
 	mkdir -p build
 	cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$(PREFIX) -S . -B build
-	cmake --build build --config Debug
+	cmake --build build -j $(CPU_CORES)
 
 test: build
-	cmake --build build --target UnitTests --config Release
+	cmake --build build --target UnitTests -j $(CPU_CORES)
 	cd build && ctest -C Release --output-on-failure
 
 test-junit: release
@@ -23,7 +34,7 @@ clean:
 	rm -rf build
 
 install: build
-	cmake --install build --config Release
+	cmake --install build
 
 uninstall:
 	rm -rf $(PREFIX)/lib/uhdm
@@ -33,7 +44,6 @@ build:
 	mkdir -p build
 	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(PREFIX) -S . -B build
 
-# TODO: the following static libraries should probably be all distributed together in libuhdm.a (ar ADDLIB)
 test_install:
-	cmake --build build --target test_inst --config Release
+	cmake --build build --target test_inst  -j $(CPU_CORES)
 	find build/bin -name test_inst* -exec {} \;

--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,15 @@ endif
 PREFIX?=/usr/local
 
 release: build
-	cmake --build build -j $(CPU_CORES)
+	cmake --build build --config Release -j $(CPU_CORES)
 
 debug:
 	mkdir -p build
 	cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$(PREFIX) -S . -B build
-	cmake --build build -j $(CPU_CORES)
+	cmake --build build --config Debug -j $(CPU_CORES)
 
 test: build
-	cmake --build build --target UnitTests -j $(CPU_CORES)
+	cmake --build build --target UnitTests --config Release -j $(CPU_CORES)
 	cd build && ctest -C Release --output-on-failure
 
 test-junit: release
@@ -34,7 +34,7 @@ clean:
 	rm -rf build
 
 install: build
-	cmake --install build
+	cmake --install build --config Release
 
 uninstall:
 	rm -rf $(PREFIX)/lib/uhdm
@@ -45,5 +45,5 @@ build:
 	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(PREFIX) -S . -B build
 
 test_install:
-	cmake --build build --target test_inst  -j $(CPU_CORES)
+	cmake --build build --target test_inst --config Release -j $(CPU_CORES)
 	find build/bin -name test_inst* -exec {} \;

--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -1510,10 +1510,10 @@ proc generate_code { models } {
         puts "capnp_path = $capnp_path"
         set capnp_path [file dirname $capnp_path]
 
-        if { $tcl_platform(platform) == "windows" } {
+        if { ($tcl_platform(platform) == "windows") && (![info exists ::env(MSYSTEM)]) } {
             exec -ignorestderr cmd /c "set PATH=$capnp_path;%PATH%; && cd /d [project_path]/src && $capnp_path/capnp.exe compile -oc++ UHDM.capnp"
         } else {
-            exec -ignorestderr sh -c "export PATH=$capnp_path; $capnp_path/capnp compile -oc++:. [project_path]/src/UHDM.capnp"
+            exec -ignorestderr sh -c "export PATH=$capnp_path:\$PATH; $capnp_path/capnp compile -oc++:. [project_path]/src/UHDM.capnp"
         }
     }
 

--- a/templates/Serializer_restore.cpp
+++ b/templates/Serializer_restore.cpp
@@ -28,13 +28,15 @@
 #include <fcntl.h>
 #include <limits.h>
 
-#if (defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__))
+#if defined(_MSC_VER)
   #include <io.h>
   #pragma warning(push)
   #pragma warning(disable : 4244)  // 'argument' : conversion from 'type1' to 'type2', possible loss of data
 #else
   #include <unistd.h>
-  #define O_BINARY 0
+  #if !(defined(__MINGW32__) || defined(__CYGWIN__))
+    #define O_BINARY 0
+  #endif
 #endif
 
 #include <vector>

--- a/templates/Serializer_save.cpp
+++ b/templates/Serializer_save.cpp
@@ -27,14 +27,16 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
-#if (defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__))
+#if defined(_MSC_VER)
   #include <io.h>
   #define S_IRWXU (_S_IREAD | _S_IWRITE)
   #pragma warning(push)
   #pragma warning(disable : 4267)  // 'var' : conversion from 'size_t' to 'type', possible loss of data
 #else
   #include <unistd.h>
-  #define O_BINARY 0
+  #if !(defined(__MINGW32__) || defined(__CYGWIN__))
+    #define O_BINARY 0
+  #endif
 #endif
 
 #include <vector>


### PR DESCRIPTION
Support for CI Builds on GHA

* Includes Linux, MSYS+GCC and Windows+MSVS
* Fixed a few compile errors to support all configurations
* Added a few additional files/folders to ignore
* Don't assume LF for all editors across platforms
* Updated Makefile to support parallel builds

