### PR TITLE
ci: rework 'main' workflow

### DIFF
--- a/.github/mingw-w64-UHDM/PKGBUILD
+++ b/.github/mingw-w64-UHDM/PKGBUILD
@@ -1,0 +1,38 @@
+_realname=UHDM
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=ci
+pkgrel=1
+pkgdesc="DESCRIPTION (mingw-w64)"
+arch=('any')
+url="URL"
+license=('license')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-zlib"
+             "${MINGW_PACKAGE_PREFIX}-tcl")
+
+build() {
+  export CC=gcc
+  export CXX=g++
+  export PREFIX=/usr/include
+  export CMAKE_GENERATOR=Ninja
+  export NO_TCMALLOC=On
+
+  cd ${srcdir}/../../../
+
+  make release
+}
+
+package() {
+  cd ${srcdir}/../../../
+  make DESTDIR="${pkgdir}" install
+  make DESTDIR="${pkgdir}" test_install
+}
+
+test() {
+  cd ${srcdir}/../../../
+  make test
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,13 +5,21 @@ on:
   pull_request:
 
 jobs:
+
+
   linux-gcc:
     runs-on: ubuntu-latest
+
     defaults:
       run:
         shell: bash
+    env:
+      CC: gcc-9
+      CXX: g++-9
+      PREFIX: /usr/include
 
     steps:
+
     - name: Install dependencies
       run: |
         sudo apt-get update -qq
@@ -22,12 +30,6 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: 0
-
-    - name: Configure shell
-      run: |
-        echo 'CC=gcc-9' >> $GITHUB_ENV
-        echo 'CXX=g++-9' >> $GITHUB_ENV
-        echo 'PREFIX=/usr/include' >> $GITHUB_ENV
 
     - name: Show shell configuration
       run: |
@@ -45,57 +47,6 @@ jobs:
         sudo make install
         make test_install
 
-  msys2-gcc:
-    if: false # disable for the time being until we figure out the reason for slow builds and intermittent link issues
-    runs-on: windows-latest
-    defaults:
-      run:
-        shell: msys2 {0}
-
-    steps:
-    - name: Setup Msys2
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: MSYS
-        update: true
-        install: make cmake ninja gcc
-      env:
-        MSYS2_PATH_TYPE: inherit
-
-    - name: Configure Git
-      run: git config --global core.autocrlf input
-      shell: bash
-
-    - name: Git pull
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        fetch-depth: 0
-
-    - name: Configure shell
-      run: |
-        echo 'CC=gcc' >> $GITHUB_ENV
-        echo 'CXX=g++' >> $GITHUB_ENV
-        echo 'PREFIX=$PWD/install' >> $GITHUB_ENV
-        echo 'CMAKE_GENERATOR=Ninja' >> $GITHUB_ENV
-        echo 'NO_TCMALLOC=On' >> $GITHUB_ENV
-
-    - name: Show shell configuration
-      run: |
-        env
-        where cmake && cmake --version
-        where make && make --version
-        where ninja && ninja --version
-        where tclsh && echo 'puts [info patchlevel];exit 0' | tclsh
-        where $CC && $CC --version
-        where $CXX && $CXX --version
-
-    - name: Build & Test
-      run: |
-        make release
-        make test
-        make install
-        make test_install
 
   windows-msvc:
     runs-on: windows-latest
@@ -105,6 +56,7 @@ jobs:
         shell: cmd
 
     steps:
+
     - name: Install Core Dependencies
       run: |
         choco install -y make

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,0 +1,34 @@
+name: 'msys2'
+
+on:
+  push:
+  pull_request:
+
+jobs:
+
+  windows-msys2:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+
+    - run: git config --global core.autocrlf input
+      shell: bash
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: base-devel git mingw-w64-x86_64-toolchain
+
+    - name: Build and install UHDM
+      run: |
+        cd .github/mingw-w64-UHDM
+        makepkg-mingw --noconfirm --noprogressbar -sCLf
+        pacman --noconfirm -U mingw-w64-*-any.pkg.tar.zst

--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -48,7 +48,6 @@ proc project_path {} {
     return [file dirname [file dirname $myLocation]]
 }
 
-
 file mkdir [project_path]/src
 file mkdir [project_path]/headers
 
@@ -125,9 +124,9 @@ proc printMethods { classname type vpi card {real_type ""} } {
       const std::string\\& name = (!parent->VpiName().empty()) ? parent->VpiName() : parent->VpiDefName();
       UHDM_OBJECT_TYPE parent_type = (parent != nullptr) ? parent->UhdmType() : uhdmunsupported_stmt;
       UHDM_OBJECT_TYPE actual_parent_type = (actual_parent != nullptr) ? actual_parent->UhdmType() : uhdmunsupported_stmt;
-      bool skip_name = (actual_parent_type == uhdmref_obj) || (parent_type == uhdmmethod_func_call) || 
-                       (parent_type == uhdmmethod_task_call) || (parent_type == uhdmfunc_call) || 
-                       (parent_type == uhdmtask_call) || (parent_type == uhdmsys_func_call) || 
+      bool skip_name = (actual_parent_type == uhdmref_obj) || (parent_type == uhdmmethod_func_call) ||
+                       (parent_type == uhdmmethod_task_call) || (parent_type == uhdmfunc_call) ||
+                       (parent_type == uhdmtask_call) || (parent_type == uhdmsys_func_call) ||
                        (parent_type == uhdmsys_task_call);
       if ((!name.empty()) \\&\\& (!skip_name))
         names.push_back(name);
@@ -145,7 +144,7 @@ proc printMethods { classname type vpi card {real_type ""} } {
     }
     if (!fullName.empty()) {
       ((${classname}*)this)->VpiFullName(fullName);
-    } 
+    }
     return serializer_->symbolMaker.GetSymbol(${vpi}_);
   }
 }\n"
@@ -1513,7 +1512,7 @@ proc generate_code { models } {
         if { ($tcl_platform(platform) == "windows") && (![info exists ::env(MSYSTEM)]) } {
             exec -ignorestderr cmd /c "set PATH=$capnp_path;%PATH%; && cd /d [project_path]/src && $capnp_path/capnp.exe compile -oc++ UHDM.capnp"
         } else {
-            exec -ignorestderr sh -c "export PATH=$capnp_path:\$PATH; $capnp_path/capnp compile -oc++:. [project_path]/src/UHDM.capnp"
+            exec -ignorestderr sh -c "export PATH=\$(cygpath -u -a $capnp_path):\$PATH; $capnp_path/capnp compile -oc++:. [project_path]/src/UHDM.capnp"
         }
     }
 


### PR DESCRIPTION
Coming from #362

In the linux-gcc job, global envvars are used instead of `$GITHUB_ENV`. That's just an style change.

In the msys2-gcc job, several changes are applied:

- MINGW64 is used instead of MSYS. See https://www.msys2.org/wiki/Creating-Packages/#general-information.
  - Therefore, `mingw-w64-x86_64-*` versions of cmake, ninja and gcc are installed.
- Instead of inheriting the environment (which is likely to produce problems), envvars are defined in `~/.bashrc`.
- Step "Show shell configuration" is removed, because it was failing for no obvious reason.
- Build and Test are split in two steps.

Currently the msys2-gcc job is failing because cmake seems to try using `cmd.exe`: https://github.com/umarcor/UHDM/runs/1306520522?check_suite_focus=true#step:6:32