### PR TITLE
Mark final classes as final

### DIFF
--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -1200,12 +1200,14 @@ proc generate_code { models } {
         set vpi_iterator($classname) ""
 
         if {$modeltype == "class_def"} {
+            regsub -all {<FINAL_CLASS>} $template "" template
             regsub -all {<FINAL_DESTRUCTOR>} $template "" template
             regsub -all {<VIRTUAL>} $template "virtual " template
             regsub -all {<OVERRIDE_OR_FINAL>}  $template "override" template
             regsub -all {<DISABLE_OBJECT_FACTORY>} $template "#if 0 // This class cannot be instantiated" template
             regsub -all {<END_DISABLE_OBJECT_FACTORY>} $template "#endif" template
         } else {
+            regsub -all {<FINAL_CLASS>} $template "final" template
             regsub -all {<FINAL_DESTRUCTOR>} $template "final" template
             regsub -all {<VIRTUAL>} $template "virtual " template
             regsub -all {<OVERRIDE_OR_FINAL>}  $template "final" template

--- a/templates/class_header.h
+++ b/templates/class_header.h
@@ -33,7 +33,7 @@
 
 namespace UHDM {
 
-  class <CLASSNAME> : public <EXTENDS> {
+  class <CLASSNAME> <FINAL_CLASS> : public <EXTENDS> {
   public:
     // Implicit constructor used to initialize all members,
     // comment: <CLASSNAME>();


### PR DESCRIPTION
Some of the classes generated by `model_gen.tcl` have their destructors marked as `final`. Because the classes themselves aren't `final`, during compilation `clang` outputs lots of these warnings:
```
./../image/include/uhdm/headers/constr_if_else.h:40:31: warning: class with destructor marked 'final' cannot be inherited from [-Wfinal-dtor-non-final-class]
```
This PR resolves the issue by adding the `final` keyword to the class declaration, which causes the warning to disappear.