### PR TITLE
IWYU: Make headers self-contained.

### DIFF
--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -109,9 +109,9 @@ proc printMethods { classname type vpi card {real_type ""} } {
 
 
         if {$type == "std::string"} {
-            append methods "\n    ${virtual}bool [string toupper ${vpi} 0 0](const ${type}${pointer}\\& data)$final;\n"
+            append methods "\n  ${virtual}bool [string toupper ${vpi} 0 0](const ${type}${pointer}\\& data)$final;\n"
             if {$vpi == "vpiFullName" } {
-                append methods "\n    ${virtual}const ${type}${pointer}\\&  [string toupper ${vpi} 0 0]() const$final;\n"
+                append methods "\n  ${virtual}const ${type}${pointer}\\&  [string toupper ${vpi} 0 0]() const$final;\n"
                 append methods_cpp "\nconst ${type}${pointer}\\&  ${classname}::[string toupper ${vpi} 0 0]() const {
   if (${vpi}_) {
     return serializer_->symbolMaker.GetSymbol(${vpi}_);
@@ -151,21 +151,21 @@ proc printMethods { classname type vpi card {real_type ""} } {
   }
 }\n"
             } else {
-                append methods "\n    ${virtual}const ${type}${pointer}\\& [string toupper ${vpi} 0 0]() const$final;\n"
+                append methods "\n  ${virtual}const ${type}${pointer}\\& [string toupper ${vpi} 0 0]() const$final;\n"
                 append methods_cpp "\nconst ${type}${pointer}\\& ${classname}::[string toupper ${vpi} 0 0]() const { return serializer_->symbolMaker.GetSymbol(${vpi}_); }\n"
             }
             append methods_cpp "\nbool ${classname}::[string toupper ${vpi} 0 0](const ${type}${pointer}\\& data) { ${vpi}_ = serializer_->symbolMaker.Make(data); return true; }\n"
         } else {
-            append methods "\n    ${virtual}${const}${type}${pointer} [string toupper ${vpi} 0 0]() const$final { return ${vpi}_; }\n"
+            append methods "\n  ${virtual}${const}${type}${pointer} [string toupper ${vpi} 0 0]() const$final { return ${vpi}_; }\n"
             if {$vpi == "vpiParent"} {
-                append methods "\n    virtual bool [string toupper ${vpi} 0 0](${type}${pointer} data) final {${check} ${vpi}_ = data; if (data) uhdmParentType_ = data->UhdmType(); return true;}\n"
+                append methods "\n  virtual bool [string toupper ${vpi} 0 0](${type}${pointer} data) final {${check} ${vpi}_ = data; if (data) uhdmParentType_ = data->UhdmType(); return true;}\n"
             } else {
-                append methods "\n    ${virtual}bool [string toupper ${vpi} 0 0](${type}${pointer} data)$final {${check} ${vpi}_ = data; return true;}\n"
+                append methods "\n  ${virtual}bool [string toupper ${vpi} 0 0](${type}${pointer} data)$final {${check} ${vpi}_ = data; return true;}\n"
             }
         }
     } elseif {$card == "any"} {
-        append methods "\n    VectorOf${type}* [string toupper ${vpi} 0 0]() const { return ${vpi}_; }\n"
-        append methods "\n    bool [string toupper ${vpi} 0 0](VectorOf${type}* data) {${check} ${vpi}_ = data; return true;}\n"
+        append methods "\n  VectorOf${type}* [string toupper ${vpi} 0 0]() const { return ${vpi}_; }\n"
+        append methods "\n  bool [string toupper ${vpi} 0 0](VectorOf${type}* data) {${check} ${vpi}_ = data; return true;}\n"
     }
     return $methods
 }
@@ -212,12 +212,12 @@ proc printMembers { type vpi card } {
             set default_assignment "nullptr"
         }
         if {$type == "std::string"} {
-            append members "\n    SymbolFactory::ID ${vpi}_ = 0;\n"
+            append members "\n  SymbolFactory::ID ${vpi}_ = 0;\n"
         } else {
-            append members "\n    ${type}${pointer} ${vpi}_ = ${default_assignment};\n"
+            append members "\n  ${type}${pointer} ${vpi}_ = ${default_assignment};\n"
         }
     } elseif {$card == "any"} {
-        append members "\n    VectorOf${type}* ${vpi}_ = nullptr;\n"
+        append members "\n  VectorOf${type}* ${vpi}_ = nullptr;\n"
     }
     return $members
 }
@@ -1255,7 +1255,7 @@ proc generate_code { models } {
 
         if {$modeltype == "class_def"} {
             # DeepClone() not implemented for class_def; just declare to narrow the covariant return type.
-            append methods($classname) "\n    ${classname}* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override = 0;\n"
+            append methods($classname) "\n  ${classname}* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override = 0;\n"
         } else {
             # Builtin properties do not need to be specified in each models
             # Builtins: "vpiParent, Parent type, vpiFile, Id" method and field

--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -1002,7 +1002,7 @@ proc write_uhdm_h { headers} {
     set uhdm_content [read $fid]
     close $fid
 
-    set name_id_map "\nstd::string UHDM::UhdmName(UHDM_OBJECT_TYPE type) \{
+    set name_id_map "\nstd::string UhdmName(UHDM_OBJECT_TYPE type) \{
       switch (type) \{
 "
     foreach id [array names DEFINE_ID] {

--- a/model_gen/model_gen.tcl
+++ b/model_gen/model_gen.tcl
@@ -75,7 +75,7 @@ proc parse_vpi_user_defines { } {
 set OBJECTID 2000
 
 proc printMethods { classname type vpi card {real_type ""} } {
-    global methods_cpp
+    global methods_cpp group_headers
     set methods ""
     if {$type == "string"} {
         set type "std::string"
@@ -97,6 +97,7 @@ proc printMethods { classname type vpi card {real_type ""} } {
     }
     set check ""
     if {$type == "any"} {
+        append group_headers "#include \"${real_type}.h\"\n"
         set check "if (!${real_type}GroupCompliant(data)) return false;"
     }
     if {$card == "1"} {
@@ -1148,7 +1149,7 @@ proc process_baseclass { baseclass classname modeltype capnpIndex } {
 }
 
 proc generate_code { models } {
-    global ID BASECLASS DEFINE_ID SAVE RESTORE working_dir methods_cpp VISITOR VISITOR_RELATIONS CLASS_LISTENER
+    global ID BASECLASS DEFINE_ID SAVE RESTORE working_dir methods_cpp group_headers VISITOR VISITOR_RELATIONS CLASS_LISTENER
     global VPI_LISTENERS VPI_LISTENERS_HEADER VPI_ANY_LISTENERS MODEL_TYPE
     global uhdm_name_map headers vpi_handle_body_all vpi_handle_body vpi_iterator vpi_iterate_body vpi_handle_by_name_body vpi_handle_by_name_body_all
     global tcl_platform myProjetPathNoNormalize
@@ -1196,6 +1197,7 @@ proc generate_code { models } {
         set baseclass ""
         set methods($classname) ""
         set members($classname) ""
+        set group_headers ""
         set SAVE($classname) ""
         set RESTORE($classname) ""
         set capnp_schema($classname) ""
@@ -1269,9 +1271,9 @@ proc generate_code { models } {
             append methods($classname) [printMethods $classname "unsigned int" uhdmId 1]
             append members($classname) [printMembers "unsigned int" uhdmId 1]
             if [regexp {_call} ${classname}] {
-                append methods($classname) "\n    tf_call* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override;\n"
+                append methods($classname) "\n  tf_call* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override;\n"
             } else {
-                append methods($classname) "\n    ${classname}* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override;\n"
+                append methods($classname) "\n  ${classname}* DeepClone(Serializer* serializer, ElaboratorListener* elab_listener, BaseClass* parent) const override;\n"
             }
             append vpi_handle_body($classname) [printGetHandleBody $classname BaseClass vpiParent vpiParent 1]
             lappend capnp_schema($classname) [list vpiParent UInt64]
@@ -1446,13 +1448,14 @@ proc generate_code { models } {
 
         if {($type_specified == 0) && ($modeltype == "obj_def")} {
             set vpiclasstype [makeVpiName $classname]
-            append methods($classname) "\n    unsigned int VpiType() const final { return $vpiclasstype; }\n"
+            append methods($classname) "\n  unsigned int VpiType() const final { return $vpiclasstype; }\n"
             lappend vpi_get_body_inst($classname) [list $classname "unsigned int" vpiType 1]
 
         }
         regsub -all {<METHODS>} $template $methods($classname) template
         regsub -all {<MEMBERS>} $template $members($classname) template
         regsub -all {<EXTENDS>} $template BaseClass template
+        regsub -all {<GROUP_HEADER_DEPENDENCY>} $template $group_headers template
 
         set_content_if_change "[project_path]/headers/$classname.h" $template
 

--- a/templates/Serializer.h
+++ b/templates/Serializer.h
@@ -26,6 +26,11 @@
 
 #ifndef SERIALIZER_UHDM_H
 #define SERIALIZER_UHDM_H
+
+#include <string>
+#include <vector>
+#include <map>
+
 #include <iostream>
 #include <functional>
 #include "uhdm.h"
@@ -35,7 +40,7 @@ namespace UHDM {
   typedef std::function<void(const std::string&)> ErrorHandler;
 
   static void DefaultErrorHandler(const std::string& errorMsg) { std::cout << errorMsg << std::endl; }
-  
+
   class Serializer {
   public:
     Serializer() : incrId_(0), objId_(0), errorHandler(DefaultErrorHandler) {symbolMaker.Make("");}
@@ -45,7 +50,7 @@ namespace UHDM {
     ErrorHandler GetErrorHandler() { return errorHandler; }
     const std::vector<vpiHandle> Restore(const std::string& file);
     std::map<std::string, unsigned long> ObjectStats();
-    
+
 <FACTORIES_METHODS>
     std::vector<any*>* MakeAnyVec() { return anyVectMaker.Make(); }
     vpiHandle MakeUhdmHandle(UHDM_OBJECT_TYPE type, const void* object) { return uhdm_handleMaker.Make(type, object); }

--- a/templates/Serializer_restore.cpp
+++ b/templates/Serializer_restore.cpp
@@ -22,11 +22,12 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
+#include "headers/Serializer.h"
 
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #if defined(_MSC_VER)
   #include <io.h>
@@ -39,20 +40,19 @@
   #endif
 #endif
 
-#include <vector>
-#include <map>
 #include <iostream>
+#include <map>
+#include <vector>
 
 #include <capnp/message.h>
 #include <capnp/serialize-packed.h>
 
-#include "headers/uhdm_types.h"
+#include "UHDM.capnp.h"
 #include "headers/containers.h"
 #include "headers/uhdm.h"
-#include "UHDM.capnp.h"
-#include "headers/Serializer.h"
-using namespace UHDM;
+#include "headers/uhdm_types.h"
 
+namespace UHDM {
 const std::vector<vpiHandle> Serializer::Restore(const std::string& file) {
   Purge();
   std::vector<vpiHandle> designs;
@@ -85,3 +85,4 @@ const std::vector<vpiHandle> Serializer::Restore(const std::string& file) {
 #if (defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__))
   #pragma warning(pop)
 #endif
+}  // namespace UHDM

--- a/templates/Serializer_save.cpp
+++ b/templates/Serializer_save.cpp
@@ -22,10 +22,11 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
+#include "headers/Serializer.h"
 
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #if defined(_MSC_VER)
   #include <io.h>
@@ -39,21 +40,20 @@
   #endif
 #endif
 
-#include <vector>
-#include <map>
 #include <iostream>
+#include <map>
+#include <string>
+#include <vector>
 
 #include <capnp/message.h>
 #include <capnp/serialize-packed.h>
 
-#include "headers/uhdm_types.h"
+#include "UHDM.capnp.h"
 #include "headers/containers.h"
 #include "headers/uhdm.h"
-#include "UHDM.capnp.h"
-#include "headers/Serializer.h"
+#include "headers/uhdm_types.h"
 
-using namespace UHDM;
-
+namespace UHDM {
 void Serializer::SetId(const BaseClass* p, unsigned long id) {
   allIds_.insert(std::make_pair(p, id));
 }
@@ -72,7 +72,8 @@ unsigned long Serializer::GetId(const BaseClass* p) {
 
 <UHDM_NAME_MAP>
 
-std::string UHDM::VpiTypeName(vpiHandle h) {
+// From uhdm_types.h
+std::string VpiTypeName(vpiHandle h) {
   uhdm_handle* handle = (uhdm_handle*) h;
   BaseClass* obj = (BaseClass*) handle->object;
   return UhdmName(obj->UhdmType());
@@ -140,3 +141,4 @@ void Serializer::Save(const std::string& file) {
 #if (defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__))
   #pragma warning(pop)
 #endif
+}  // namespace UHDM

--- a/templates/VpiListener.h
+++ b/templates/VpiListener.h
@@ -28,23 +28,20 @@
 #define UHDM_VPILISTENER_CLASS_H
 
 #include "headers/uhdm_forward_decl.h"
+#include "include/vpi_user.h"
 
 namespace UHDM {
+class VpiListener {
+public:
+  // Use implicit constructor to initialize all members
+  // VpiListener()
 
-  class VpiListener {
-  public:
-    // Use implicit constructor to initialize all members
-    // VpiListener()
-
-    virtual ~VpiListener() {}
+  virtual ~VpiListener() {}
 
 <VPI_LISTENER_METHODS>
-
-  protected:
-
-  };
-
 };
+
+}  // namespace UHDM
 
 
 #endif

--- a/templates/VpiListener.h
+++ b/templates/VpiListener.h
@@ -27,21 +27,23 @@
 #ifndef UHDM_VPILISTENER_CLASS_H
 #define UHDM_VPILISTENER_CLASS_H
 
+#include "headers/uhdm_forward_decl.h"
+
 namespace UHDM {
-  
+
   class VpiListener {
   public:
     // Use implicit constructor to initialize all members
     // VpiListener()
-    
+
     virtual ~VpiListener() {}
 
 <VPI_LISTENER_METHODS>
 
   protected:
-    
+
   };
-  
+
 };
 
 

--- a/templates/class_header.h
+++ b/templates/class_header.h
@@ -70,13 +70,13 @@ private:
 
 class VectorOf<CLASSNAME>Factory {
   friend Serializer;
- public:
+public:
  std::vector<<CLASSNAME>*>* Make() {
    std::vector<<CLASSNAME>*>* obj = new std::vector<<CLASSNAME>*>();
    objects_.push_back(obj);
    return obj;
  }
- private:
+private:
  std::vector<std::vector<<CLASSNAME>*>*> objects_;
 };
 

--- a/templates/class_header.h
+++ b/templates/class_header.h
@@ -32,6 +32,8 @@
 
 #include "<EXTENDS>.h"
 
+<GROUP_HEADER_DEPENDENCY>
+
 namespace UHDM {
 class <CLASSNAME> <FINAL_CLASS> : public <EXTENDS> {
 public:

--- a/templates/class_header.h
+++ b/templates/class_header.h
@@ -29,25 +29,26 @@
 #include "SymbolFactory.h"
 #include "BaseClass.h"
 #include "containers.h"
-#include "uhdm.h"
+
+#include "<EXTENDS>.h"
 
 namespace UHDM {
+class <CLASSNAME> <FINAL_CLASS> : public <EXTENDS> {
+public:
+  // Implicit constructor used to initialize all members,
+  // comment: <CLASSNAME>();
+  <VIRTUAL>~<CLASSNAME>() <FINAL_DESTRUCTOR> {}
+  <METHODS>
+  <VIRTUAL> UHDM_OBJECT_TYPE UhdmType() const <OVERRIDE_OR_FINAL> { return uhdm<CLASSNAME>; }
 
-  class <CLASSNAME> <FINAL_CLASS> : public <EXTENDS> {
-  public:
-    // Implicit constructor used to initialize all members,
-    // comment: <CLASSNAME>();
-    <VIRTUAL>~<CLASSNAME>() <FINAL_DESTRUCTOR> {}
-    <METHODS>
-   <VIRTUAL> UHDM_OBJECT_TYPE UhdmType() const <OVERRIDE_OR_FINAL> { return uhdm<CLASSNAME>; }   
-  private:
-    <MEMBERS>
-  };
+private:
+  <MEMBERS>
+};
 
- <DISABLE_OBJECT_FACTORY> 
-  class <CLASSNAME>Factory {
+<DISABLE_OBJECT_FACTORY>
+class <CLASSNAME>Factory {
   friend Serializer;
-  public:
+public:
   <CLASSNAME>* Make() {
     <CLASSNAME>* obj = new <CLASSNAME>();
     objects_.push_back(obj);
@@ -60,24 +61,25 @@ namespace UHDM {
         break;
       }
     }
-  }   
-  private:
-    std::vector<<CLASSNAME>*> objects_;
-  };
- <END_DISABLE_OBJECT_FACTORY> 
-  
-  class VectorOf<CLASSNAME>Factory {
-  friend Serializer;
-  public:
-  std::vector<<CLASSNAME>*>* Make() {
-    std::vector<<CLASSNAME>*>* obj = new std::vector<<CLASSNAME>*>();
-    objects_.push_back(obj);
-    return obj;
   }
-  private:
-  std::vector<std::vector<<CLASSNAME>*>*> objects_;
-  };
 
+private:
+  std::vector<<CLASSNAME>*> objects_;
 };
+<END_DISABLE_OBJECT_FACTORY>
+
+class VectorOf<CLASSNAME>Factory {
+  friend Serializer;
+ public:
+ std::vector<<CLASSNAME>*>* Make() {
+   std::vector<<CLASSNAME>*>* obj = new std::vector<<CLASSNAME>*>();
+   objects_.push_back(obj);
+   return obj;
+ }
+ private:
+ std::vector<std::vector<<CLASSNAME>*>*> objects_;
+};
+
+}  // namespace UHDM
 
 #endif

--- a/templates/clone_tree.cpp
+++ b/templates/clone_tree.cpp
@@ -22,10 +22,10 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
-
-#include "uhdm.h"
 #include "clone_tree.h"
+
 #include "ElaboratorListener.h"
+#include "uhdm.h"
 
 using namespace UHDM;
 
@@ -38,8 +38,8 @@ BaseClass* clone_tree (const BaseClass* root, Serializer& s, ElaboratorListener*
 // Hardcoded implementations
 
 net* ElaboratorListener::bindNet(const std::string& name) {
-  for (InstStack::reverse_iterator i = instStack_.rbegin(); 
-       i != instStack_.rend(); ++i ) { 
+  for (InstStack::reverse_iterator i = instStack_.rbegin();
+       i != instStack_.rend(); ++i ) {
     ComponentMap& netMap = std::get<0>((*i).second);
     ComponentMap::iterator netItr = netMap.find(name);
     if (netItr != netMap.end()) {
@@ -51,14 +51,14 @@ net* ElaboratorListener::bindNet(const std::string& name) {
 
 // Bind to a net or parameter in the current instance
 any* ElaboratorListener::bindAny(const std::string& name) {
-  for (InstStack::reverse_iterator i = instStack_.rbegin(); 
-       i != instStack_.rend(); ++i ) { 
+  for (InstStack::reverse_iterator i = instStack_.rbegin();
+       i != instStack_.rend(); ++i ) {
     ComponentMap& netMap = std::get<0>((*i).second);
     ComponentMap::iterator netItr = netMap.find(name);
     if (netItr != netMap.end()) {
       return (any*) (*netItr).second;
     }
-    
+
     ComponentMap& paramMap = std::get<1>((*i).second);
     ComponentMap::iterator paramItr = paramMap.find(name);
     if (paramItr != paramMap.end()) {
@@ -70,8 +70,8 @@ any* ElaboratorListener::bindAny(const std::string& name) {
 
 // Bind to a param in the current instance
 any* ElaboratorListener::bindParam(const std::string& name) {
-  for (InstStack::reverse_iterator i = instStack_.rbegin(); 
-       i != instStack_.rend(); ++i ) { 
+  for (InstStack::reverse_iterator i = instStack_.rbegin();
+       i != instStack_.rend(); ++i ) {
     ComponentMap& paramMap = std::get<1>((*i).second);
     ComponentMap::iterator paramItr = paramMap.find(name);
     if (paramItr != paramMap.end()) {
@@ -83,8 +83,8 @@ any* ElaboratorListener::bindParam(const std::string& name) {
 
 // Bind to a function or task in the current scope
 any* ElaboratorListener::bindTaskFunc(const std::string& name, const class_var* prefix) {
-  for (InstStack::reverse_iterator i = instStack_.rbegin(); 
-       i != instStack_.rend(); ++i ) { 
+  for (InstStack::reverse_iterator i = instStack_.rbegin();
+       i != instStack_.rend(); ++i ) {
     ComponentMap& funcMap = std::get<2>((*i).second);
     ComponentMap::iterator funcItr = funcMap.find(name);
     if (funcItr != funcMap.end()) {
@@ -98,7 +98,7 @@ any* ElaboratorListener::bindTaskFunc(const std::string& name, const class_var* 
       while (def) {
 	if (def->Task_funcs()) {
 	  for (task_func* tf : *def->Task_funcs()) {
-	    if (tf->VpiName() == name) 
+	    if (tf->VpiName() == name)
 	      return tf;
 	  }
 	}
@@ -114,7 +114,7 @@ any* ElaboratorListener::bindTaskFunc(const std::string& name, const class_var* 
   }
   return nullptr;
 }
-  
+
 bool ElaboratorListener::isFunctionCall(const std::string& name, const expr* prefix) {
   if (instStack_.size()) {
     for (InstStack::reverse_iterator i = instStack_.rbegin();
@@ -292,9 +292,9 @@ constant* constant::DeepClone(Serializer* serializer, ElaboratorListener* elabor
     return clone;
   } else {
     return (constant*) this;
-  }                             
+  }
 }
-  
+
 tagged_pattern* tagged_pattern::DeepClone(Serializer* serializer, ElaboratorListener* elaborator, BaseClass* parent) const {
   if (elaborator->uniquifyTypespec()) {
     tagged_pattern* const clone = serializer->MakeTagged_pattern();
@@ -302,15 +302,15 @@ tagged_pattern* tagged_pattern::DeepClone(Serializer* serializer, ElaboratorList
     *clone = *this;
     clone->UhdmId(id);
     clone->VpiParent(parent);
-    if (auto obj = Typespec()) clone->Typespec(obj->DeepClone(serializer, elaborator, clone));                             
+    if (auto obj = Typespec()) clone->Typespec(obj->DeepClone(serializer, elaborator, clone));
     if (auto obj = Pattern()) clone->Pattern(obj->DeepClone(serializer, elaborator, clone));
     return clone;
   } else {
     return (tagged_pattern*) this;
-  }  
+  }
 }
 
-  
+
 tf_call* method_task_call::DeepClone(Serializer* serializer, ElaboratorListener* elaborator, BaseClass* parent) const {
   const expr* prefix = Prefix();
   if (prefix) {
@@ -752,15 +752,15 @@ void ElaboratorListener::enterTask_func(const task_func* object, const BaseClass
         varMap.insert(std::make_pair(decl->VpiName(), decl));
       }
     }
- 
+
     ComponentMap paramMap;
-    
+
     ComponentMap funcMap;
-    
+
     instStack_.push_back(std::make_pair(object, std::make_tuple(varMap, paramMap, funcMap)));
-  
+
 }
-  
+
 void ElaboratorListener::leaveTask_func(const task_func* object, const BaseClass* parent,
 				       vpiHandle handle, vpiHandle parentHandle) {
     instStack_.pop_back();

--- a/templates/clone_tree.h
+++ b/templates/clone_tree.h
@@ -22,19 +22,21 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
-
-#include <string>
-#include <vector>
-#include "sv_vpi_user.h"
-
 #ifndef UHDM_CLONE_TREE_H
 #define UHDM_CLONE_TREE_H
 
-namespace UHDM {
-  class ElaboratorListener;
+#include <string>
+#include <vector>
 
-  BaseClass* clone_tree (const BaseClass* root, Serializer& s, ElaboratorListener* elaborator = nullptr);
+#include "sv_vpi_user.h"
+
+namespace UHDM {
+class BaseClass;
+class ElaboratorListener;
+class Serializer;
+
+BaseClass* clone_tree (const BaseClass* root, Serializer& s, ElaboratorListener* elaborator = nullptr);
 
 };
 
-#endif
+#endif  // UHDM_CLONE_TREE_H

--- a/templates/group_header.cpp
+++ b/templates/group_header.cpp
@@ -22,34 +22,32 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
-
+#include "<GROUPNAME>.h"
 
 #include <iostream>
 #include "headers/uhdm.h"
-#include "<GROUPNAME>.h"
 
 namespace UHDM {
+bool <GROUPNAME>GroupCompliant(any* item) {
+  if (item == nullptr) {
+    return true;
+  }
+  BaseClass* the_item = (BaseClass*) item;
+  UHDM_OBJECT_TYPE uhdmtype = the_item->UhdmType();
+  if (<CHECKTYPE>) {
+    item->GetSerializer()->GetErrorHandler()("Internal Error: adding wrong object type (" + UhdmName(uhdmtype) + ") in a <GROUPNAME> group!\n");
+    return false;
+  }
+  return true;
+}
 
-  bool <GROUPNAME>GroupCompliant(any* item) {
-    if (item == nullptr) {
-      return true;
-    }
-    BaseClass* the_item = (BaseClass*) item;
-    UHDM_OBJECT_TYPE uhdmtype = the_item->UhdmType();
-    if (<CHECKTYPE>) {
-      item->GetSerializer()->GetErrorHandler()("Internal Error: adding wrong object type (" + UhdmName(uhdmtype) + ") in a <GROUPNAME> group!\n");   
+bool <GROUPNAME>GroupCompliant(VectorOfany* vec) {
+  for (auto item : *vec) {
+    if (!<GROUPNAME>GroupCompliant(item)) {
       return false;
     }
-    return true;
   }
+  return true;
+}
 
-  bool <GROUPNAME>GroupCompliant(VectorOfany* vec) {
-    for (auto item : *vec) {
-      if (!<GROUPNAME>GroupCompliant(item)) {
-	return false;
-      }
-    }
-    return true;
-  }
- 	     
-};
+}  // namespace UHDM

--- a/templates/group_header.h
+++ b/templates/group_header.h
@@ -26,11 +26,13 @@
 #ifndef UHDM_<UPPER_GROUPNAME>_H
 #define UHDM_<UPPER_GROUPNAME>_H
 
+#include "headers/uhdm_forward_decl.h"
+
 namespace UHDM {
 
-  bool <GROUPNAME>GroupCompliant(any* item);
-  bool <GROUPNAME>GroupCompliant(VectorOfany* vec);
- 	     
-};
+bool <GROUPNAME>GroupCompliant(any* item);
+bool <GROUPNAME>GroupCompliant(VectorOfany* vec);
+
+}  // namespace UHDM
 
 #endif

--- a/templates/uhdm.h
+++ b/templates/uhdm.h
@@ -22,12 +22,12 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
+#ifndef UHDM_H
+#define UHDM_H
 
 #include <string>
 #include <vector>
 #include <map>
-#ifndef UHDM_H
-#define UHDM_H
 
 // Missing defines from vpi_user.h, sv_vpi_user.h
 #define vpiDesign            3000
@@ -58,9 +58,10 @@
 #define vpiUnsupportedTypespec 4002
 
 // Objects not in the Standard
-#define vpiHierPath         5000 // Represents a hierarchical path 
+#define vpiHierPath         5000 // Represents a hierarchical path
 #define vpiReordered        5001 // Boolean for operations (pattern assign, concat) that has been reordered
 #define vpiElaborated       5002 // Boolean indicating UHDM has been elaborated/uniquified
+
 #include "headers/uhdm_types.h"
 #include "include/sv_vpi_user.h"
 #include "include/vhpi_user.h"

--- a/templates/uhdm_forward_decl.h
+++ b/templates/uhdm_forward_decl.h
@@ -27,9 +27,11 @@
 #ifndef UHDM_FORWARD_DECL_CLASS_H
 #define UHDM_FORWARD_DECL_CLASS_H
 
+#include <vector>
+
 namespace UHDM {
 class BaseClass;
-typedef BaseClass any;  
+typedef BaseClass any;
 typedef std::vector<BaseClass*> VectorOfany;
 <UHDM_FORWARD_DECL>
 };

--- a/templates/vpi_listener.cpp
+++ b/templates/vpi_listener.cpp
@@ -22,6 +22,7 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
+#include "headers/vpi_listener.h"
 
 #include <string.h>
 
@@ -33,12 +34,12 @@
 #include "include/sv_vpi_user.h"
 #include "include/vhpi_user.h"
 
-#include "headers/uhdm_types.h"
-#include "headers/containers.h"
-#include "headers/vpi_uhdm.h"
-#include "headers/uhdm.h"
 #include "headers/Serializer.h"
-#include "headers/vpi_listener.h"
+#include "headers/containers.h"
+#include "headers/uhdm.h"
+#include "headers/uhdm_types.h"
+#include "headers/vpi_uhdm.h"
+
 
 using namespace UHDM;
 

--- a/templates/vpi_user.cpp
+++ b/templates/vpi_user.cpp
@@ -22,6 +22,9 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
+#include "include/sv_vpi_user.h"
+#include "include/vhpi_user.h"
+
 #include <string.h>
 #if defined(_MSC_VER)
   #define strcasecmp _stricmp
@@ -35,14 +38,11 @@
 #include <string>
 #include <vector>
 
-#include "include/sv_vpi_user.h"
-#include "include/vhpi_user.h"
-
-#include "headers/uhdm_types.h"
-#include "headers/containers.h"
-#include "headers/vpi_uhdm.h"
-#include "headers/uhdm.h"
 #include "headers/Serializer.h"
+#include "headers/containers.h"
+#include "headers/uhdm.h"
+#include "headers/uhdm_types.h"
+#include "headers/vpi_uhdm.h"
 
 <HEADERS>
 
@@ -111,7 +111,7 @@ s_vpi_value* String2VpiValue(const std::string& s) {
     val->format = vpiDecStrVal;
     val->value.str = strdup(s.c_str() + pos + strlen("DEC:"));
   }
-  
+
   return val;
 }
 
@@ -142,11 +142,11 @@ std::string VpiValue2String(const s_vpi_value* value) {
   static const std::string kBinPrefix("BIN:");
   static const std::string kRealPrefix("REAL:");
   static const std::string kDecPrefix("DEC:");
-  
+
   if (!value) return "";
   switch (value->format) {
   case vpiIntVal: return kIntPrefix + std::to_string(value->value.integer);
-  case vpiUIntVal: return kUIntPrefix + std::to_string(value->value.uint);  
+  case vpiUIntVal: return kUIntPrefix + std::to_string(value->value.uint);
   case vpiScalarVal: {
     switch (value->value.scalar) {
     case vpi0: return "SCAL:0";

--- a/templates/vpi_visitor.cpp
+++ b/templates/vpi_visitor.cpp
@@ -22,6 +22,7 @@
  *
  * Created on December 14, 2019, 10:03 PM
  */
+#include "vpi_visitor.h"
 
 #include <string.h>
 
@@ -69,11 +70,11 @@ static bool showIDs = false;
 
 #endif
 
-#include "vpi_visitor.h"
+
 
 // UHDM implementation redefine these
 #ifndef vpiVarBit
-  #define vpiVarBit          vpiRegBit 
+  #define vpiVarBit          vpiRegBit
   #define vpiLogicVar        vpiReg
   #define vpiArrayVar        vpiRegArray
 #endif
@@ -95,7 +96,7 @@ std::string decompile(UHDM::any* handle) {
   return out.str();
 }
 
-  
+
 #ifdef STANDARD_VPI
 
 static std::string vpiTypeName(vpiHandle h) {
@@ -416,7 +417,7 @@ static void release_handle(vpiHandle obj_h) {
   vpi_release_handle(obj_h);
 #endif
 }
-  
+
 static std::string visit_value(s_vpi_value* value) {
   if (value == nullptr)
     return "";
@@ -428,7 +429,7 @@ static std::string visit_value(s_vpi_value* value) {
   case vpiUIntVal: {
     return std::string(std::string("|UINT:") + std::to_string(value->value.uint) + "\n");
     break;
-  }  
+  }
   case vpiStringVal: {
     const char* s = (const char*) value->value.str;
     return std::string(std::string("|STRING:") + std::string(s) + "\n");
@@ -461,7 +462,7 @@ static std::string visit_value(s_vpi_value* value) {
     const char* s = (const char*) value->value.str;
     return std::string(std::string("|DEC:") + std::string(s) + "\n");
     break;
-  }   
+  }
   default:
     break;
   }
@@ -491,25 +492,25 @@ void visit_object (vpiHandle obj_h, int indent, const char *relation, VisitedCon
   if (!obj_h)
     return;
 #ifdef STANDARD_VPI
-  
+
   static int kLevelIndent = 2;
   const bool alreadyVisited = visited->find(obj_h) != visited->end();
   visited->insert(obj_h);
 
 #else
-  
+
   static constexpr int kLevelIndent = 2;
   const uhdm_handle* const handle = (const uhdm_handle*) obj_h;
   const BaseClass* const object = (const BaseClass*) handle->object;
   const bool alreadyVisited = (visited->find(object) != visited->end());
   if (!shallowVisit)
     visited->insert(object);
-  
+
 #endif
-  
+
   unsigned int subobject_indent = indent + kLevelIndent;
   const unsigned int objectType = vpi_get(vpiType, obj_h);
- 
+
   {
     std::string hspaces;
     std::string rspaces;
@@ -524,9 +525,9 @@ void visit_object (vpiHandle obj_h, int indent, const char *relation, VisitedCon
     if (strlen(relation) != 0) {
       out << rspaces << relation << ":\n";
     }
-    
+
 #ifdef STANDARD_VPI
-    
+
     out << hspaces << vpiTypeName(obj_h) << "(" << vpi_get(vpiType, obj_h) << "): ";
 
 #else
@@ -534,7 +535,7 @@ void visit_object (vpiHandle obj_h, int indent, const char *relation, VisitedCon
     out << hspaces << UHDM::VpiTypeName(obj_h) << ": ";
 
 #endif
-    
+
     bool needs_separator = false;
     if (const char* s = vpi_get_str(vpiDefName, obj_h)) {  // defName
       out << s;
@@ -553,7 +554,7 @@ void visit_object (vpiHandle obj_h, int indent, const char *relation, VisitedCon
     if (showIDs)
       out << ", id:" << object->UhdmId();
 
-#endif    
+#endif
 
     if (objectType == vpiModule || objectType == vpiProgram || objectType == vpiClassDefn || objectType == vpiPackage ||
         objectType == vpiInterface || objectType == vpiUdp) {
@@ -631,12 +632,12 @@ void vpi_show_ids(bool show) {
 
 static std::stringstream the_output;
 
-extern "C" { 
+extern "C" {
   void vpi_decompiler (vpiHandle design) {
     std::vector<vpiHandle> designs;
     designs.push_back(design);
     UHDM::visit_designs(designs, the_output);
     std::cout << the_output.str().c_str() << std::endl;
   }
-  
+
 }

--- a/templates/vpi_visitor.h
+++ b/templates/vpi_visitor.h
@@ -26,8 +26,10 @@
 #include <string>
 #include <vector>
 #include <set>
+
 #include "sv_vpi_user.h"
 
+#include "headers/uhdm_forward_decl.h"
 
 #ifndef UHDM_VPI_VISITOR_H
 #define UHDM_VPI_VISITOR_H
@@ -36,11 +38,11 @@ namespace UHDM {
 #ifdef STANDARD_VPI
 typedef std::set<vpiHandle> VisitedContainer;
 #else
-typedef  std::set<const UHDM::BaseClass*> VisitedContainer;
+typedef  std::set<const BaseClass*> VisitedContainer;
 #endif
 
-// Visit an object, dump to given stream. 
-void visit_object (vpiHandle obj_h, int indent, const char *relation, VisitedContainer* visited, std::ostream& out, bool shallowVisit = false); 
+// Visit an object, dump to given stream.
+void visit_object (vpiHandle obj_h, int indent, const char *relation, VisitedContainer* visited, std::ostream& out, bool shallowVisit = false);
 
 // Visit designs, dump to given stream.
 void visit_designs (const std::vector<vpiHandle>& designs, std::ostream &out);
@@ -50,7 +52,7 @@ std::string visit_designs (const std::vector<vpiHandle>& designs);
 
 // For debug use in GDB
 std::string decompile(UHDM::any* handle);
-  
+
 };
 
 #endif


### PR DESCRIPTION
In the implemtntation compilation units, put the corresponding
header first to easily find incomplete header inclusions.

Signed-off-by: Henner Zeller <h.zeller@acm.org>