### PR TITLE
Make sure the vpi_user.h is always picked up from this UHDM installat…

### DIFF
--- a/include/sv_vpi_user.h
+++ b/include/sv_vpi_user.h
@@ -25,7 +25,7 @@
 #ifndef SV_VPI_USER_H
 #define SV_VPI_USER_H
 
-#include <vpi_user.h>
+#include "vpi_user.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/templates/clone_tree.h
+++ b/templates/clone_tree.h
@@ -28,7 +28,7 @@
 #include <string>
 #include <vector>
 
-#include "sv_vpi_user.h"
+#include "../include/sv_vpi_user.h"
 
 namespace UHDM {
 class BaseClass;

--- a/templates/uhdm.h
+++ b/templates/uhdm.h
@@ -62,9 +62,10 @@
 #define vpiReordered        5001 // Boolean for operations (pattern assign, concat) that has been reordered
 #define vpiElaborated       5002 // Boolean indicating UHDM has been elaborated/uniquified
 
+#include "../include/sv_vpi_user.h"
+#include "../include/vhpi_user.h"
+
 #include "headers/uhdm_types.h"
-#include "include/sv_vpi_user.h"
-#include "include/vhpi_user.h"
 #include "headers/vpi_uhdm.h"
 #include "headers/containers.h"
 

--- a/templates/uhdm_types.h
+++ b/templates/uhdm_types.h
@@ -27,7 +27,7 @@
 #define UHDM_TYPES_H
 
 #include <string>
-#include "vpi_user.h"
+#include "../include/vpi_user.h"
 
 namespace UHDM {
 class BaseClass;

--- a/templates/vpi_listener.h
+++ b/templates/vpi_listener.h
@@ -25,7 +25,7 @@
 
 #include <string>
 #include <vector>
-#include "sv_vpi_user.h"
+#include "../include/sv_vpi_user.h"
 #include "VpiListener.h"
 
 #ifndef UHDM_VPI_LISTENER_H

--- a/templates/vpi_visitor.h
+++ b/templates/vpi_visitor.h
@@ -27,7 +27,7 @@
 #include <vector>
 #include <set>
 
-#include "sv_vpi_user.h"
+#include "../include/sv_vpi_user.h"
 
 #include "headers/uhdm_forward_decl.h"
 


### PR DESCRIPTION
…ion.

To avoid conflicts with potentially also installed vpi_user.h on the
system, make an effort to always resolve include files relative to
the headers in question.

Signed-off-by: Henner Zeller <h.zeller@acm.org>