### PR TITLE
Make it possible to choose where code is generated into.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ add_custom_command(
   OUTPUT ${model-GENERATED_SRC}
   COMMAND tclsh ${PROJECT_SOURCE_DIR}/model_gen/model_gen.tcl
           ${PROJECT_SOURCE_DIR}/model/models.lst ${CMAKE_CURRENT_BINARY_DIR}
+          ${PROJECT_SOURCE_DIR}
   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
   DEPENDS ${PROJECT_SOURCE_DIR}/model_gen/model_gen.tcl
           ${PROJECT_SOURCE_DIR}/model_gen/generate_elaborator.tcl

--- a/model_gen/generate_elaborator.tcl
+++ b/model_gen/generate_elaborator.tcl
@@ -354,13 +354,13 @@ proc generate_elaborator { models } {
     regsub {<MODULE_ELABORATOR_LISTENER>} $listener_content $module_vpi_listener listener_content
     regsub {<CLASS_ELABORATOR_LISTENER>} $listener_content $class_vpi_listener listener_content
 
-    set_content_if_change "[project_path]/headers/ElaboratorListener.h" $listener_content
+    set_content_if_change "[codegen_base]/headers/ElaboratorListener.h" $listener_content
 
     set fid [open "[project_path]/templates/clone_tree.h"]
     set clone_content [read $fid]
     close $fid
 
-    set_content_if_change "[project_path]/headers/clone_tree.h" $clone_content
+    set_content_if_change "[codegen_base]/headers/clone_tree.h" $clone_content
 
     set fid [open "[project_path]/templates/clone_tree.cpp"]
     set clone_content [read $fid]
@@ -368,5 +368,5 @@ proc generate_elaborator { models } {
 
     regsub {<CLONE_IMPLEMENTATIONS>} $clone_content $clone_implementations clone_content
 
-    set_content_if_change "[project_path]/src/clone_tree.cpp" $clone_content
+    set_content_if_change "[codegen_base]/src/clone_tree.cpp" $clone_content
 }


### PR DESCRIPTION
Right now, it behaves just as the current code, but with this,
it will be possible to generate code out-of-tree as a preparation
to make it a more hermetic build.

Signed-off-by: Henner Zeller <h.zeller@acm.org>